### PR TITLE
Hardcode Imgbb API key for image uploads

### DIFF
--- a/AdminWindow.xaml
+++ b/AdminWindow.xaml
@@ -55,9 +55,6 @@
                     <TextBlock Text="Link ảnh" FontWeight="Bold" />
                     <TextBox Text="{Binding Editor.ImageUrl, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,12" />
 
-                    <TextBlock Text="API key Imgbb" FontWeight="Bold" />
-                    <PasswordBox x:Name="ApiKeyBox" Margin="0,4,0,12" />
-
                     <Button x:Name="UploadButton"
                             Content="Tải ảnh lên"
                             Click="UploadButton_Click"

--- a/AdminWindow.xaml.cs
+++ b/AdminWindow.xaml.cs
@@ -14,6 +14,8 @@ namespace HayChonGiaDung.Wpf
     public partial class AdminWindow : Window, INotifyPropertyChanged
     {
         private readonly HttpClient _httpClient = new();
+        private const string ImgbbApiKey = "PASTE_IMGBB_API_KEY_HERE";
+
         private ObservableCollection<Product> _products = new();
         private Product? _selectedProduct;
         private readonly ProductDraft _editor = new();
@@ -76,10 +78,9 @@ namespace HayChonGiaDung.Wpf
 
         private async void UploadButton_Click(object sender, RoutedEventArgs e)
         {
-            var apiKey = ApiKeyBox.Password?.Trim();
-            if (string.IsNullOrWhiteSpace(apiKey))
+            if (string.IsNullOrWhiteSpace(ImgbbApiKey))
             {
-                MessageBox.Show(this, "Vui lòng nhập API key Imgbb trước khi tải ảnh.", "Thiếu API key", MessageBoxButton.OK, MessageBoxImage.Warning);
+                MessageBox.Show(this, "Vui lòng cấu hình API key Imgbb trước khi tải ảnh.", "Thiếu API key", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
 
@@ -96,8 +97,7 @@ namespace HayChonGiaDung.Wpf
             try
             {
                 UploadButton.IsEnabled = false;
-                ApiKeyBox.IsEnabled = false;
-                var url = await UploadImageAsync(dialog.FileName, apiKey);
+                var url = await UploadImageAsync(dialog.FileName);
                 if (!string.IsNullOrEmpty(url))
                 {
                     Editor.ImageUrl = url;
@@ -115,11 +115,10 @@ namespace HayChonGiaDung.Wpf
             finally
             {
                 UploadButton.IsEnabled = true;
-                ApiKeyBox.IsEnabled = true;
             }
         }
 
-        private async Task<string?> UploadImageAsync(string filePath, string apiKey)
+        private async Task<string?> UploadImageAsync(string filePath)
         {
             var bytes = await File.ReadAllBytesAsync(filePath);
             var base64 = Convert.ToBase64String(bytes);
@@ -128,7 +127,7 @@ namespace HayChonGiaDung.Wpf
             content.Add(new StringContent(base64), "image");
             content.Add(new StringContent(Path.GetFileName(filePath)), "name");
 
-            var response = await _httpClient.PostAsync($"https://api.imgbb.com/1/upload?key={Uri.EscapeDataString(apiKey)}", content);
+            var response = await _httpClient.PostAsync($"https://api.imgbb.com/1/upload?key={Uri.EscapeDataString(ImgbbApiKey)}", content);
             if (!response.IsSuccessStatusCode)
             {
                 var error = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
## Summary
- add an Imgbb API key constant so uploads always use the configured key
- remove the API key input controls from the admin window now that the key is hardcoded

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d4a5b5888083338317b81fb4c28a5d