### PR TITLE
Hide image URL display and remove manual API key input

### DIFF
--- a/AdminWindow.xaml
+++ b/AdminWindow.xaml
@@ -36,7 +36,6 @@
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="Tên sản phẩm" Binding="{Binding Name}" Width="2*" />
                     <DataGridTextColumn Header="Giá (VNĐ)" Binding="{Binding Price}" Width="*" />
-                    <DataGridTextColumn Header="URL ảnh" Binding="{Binding ImageUrl}" Width="2*" />
                 </DataGrid.Columns>
             </DataGrid>
         </Border>
@@ -51,9 +50,6 @@
 
                     <TextBlock Text="Giá (VNĐ)" FontWeight="Bold" />
                     <TextBox Text="{Binding Editor.PriceText, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,12" />
-
-                    <TextBlock Text="Link ảnh" FontWeight="Bold" />
-                    <TextBox Text="{Binding Editor.ImageUrl, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,12" />
 
                     <Button x:Name="UploadButton"
                             Content="Tải ảnh lên"


### PR DESCRIPTION
## Summary
- remove the image URL column from the product grid so URLs are no longer shown in the admin interface
- drop the manual image URL textbox from the product editor to rely on uploads instead

## Testing
- `dotnet build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a86c08048333adbe52aecf5a1a6d