### PR TITLE
Enhance audio settings with volume control

### DIFF
--- a/SettingsService.cs
+++ b/SettingsService.cs
@@ -1,38 +1,88 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 
 namespace HayChonGiaDung.Wpf
 {
     public static class SettingsService
     {
+        private const double DefaultVolume = 0.8;
+
+        public static bool CurrentSoundOn { get; private set; } = true;
+        public static double CurrentVolume { get; private set; } = DefaultVolume;
+        private static bool _hasLoaded;
+
         private static string PathFile =>
             System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Data", "settings.json");
 
         public static void Load()
         {
+            bool soundOn = true;
+            double volume = DefaultVolume;
+
             try
             {
-                if (!File.Exists(PathFile)) { Save(true); } // mặc định bật âm
+                EnsureFileExists();
                 var json = File.ReadAllText(PathFile);
-                var obj = JsonSerializer.Deserialize<SettingsObj>(json) ?? new SettingsObj { Sound = true };
-                SoundManager.SoundOn = obj.Sound;
+                var obj = JsonSerializer.Deserialize<SettingsObj>(json) ?? new SettingsObj();
+
+                soundOn = obj.Sound;
+                volume = ClampVolume(obj.Volume ?? DefaultVolume);
             }
-            catch { SoundManager.SoundOn = true; }
+            catch
+            {
+                soundOn = true;
+                volume = DefaultVolume;
+            }
+
+            var hasChanges = !_hasLoaded || soundOn != CurrentSoundOn || Math.Abs(volume - CurrentVolume) > 0.0001;
+
+            CurrentSoundOn = soundOn;
+            CurrentVolume = volume;
+            _hasLoaded = true;
+
+            if (hasChanges)
+            {
+                SoundManager.ApplySettings(CurrentSoundOn, CurrentVolume);
+            }
         }
 
-        public static void Save(bool soundOn)
+        public static void Save(bool soundOn, double volume)
+        {
+            CurrentSoundOn = soundOn;
+            CurrentVolume = ClampVolume(volume);
+            _hasLoaded = true;
+
+            var payload = new SettingsObj
+            {
+                Sound = CurrentSoundOn,
+                Volume = CurrentVolume
+            };
+
+            WriteToDisk(payload);
+            SoundManager.ApplySettings(CurrentSoundOn, CurrentVolume);
+        }
+
+        private static void EnsureFileExists()
+        {
+            if (File.Exists(PathFile)) return;
+            WriteToDisk(new SettingsObj { Sound = true, Volume = DefaultVolume });
+        }
+
+        private static void WriteToDisk(SettingsObj obj)
         {
             Directory.CreateDirectory(System.IO.Path.GetDirectoryName(PathFile)!);
-            var json = JsonSerializer.Serialize(new SettingsObj { Sound = soundOn }, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(obj, new JsonSerializerOptions { WriteIndented = true });
             File.WriteAllText(PathFile, json);
-            SoundManager.SoundOn = soundOn;
         }
 
-        private class SettingsObj { public bool Sound { get; set; } }
+        private static double ClampVolume(double volume)
+            => Math.Clamp(volume, 0.0, 1.0);
+
+        private class SettingsObj
+        {
+            public bool Sound { get; set; } = true;
+            public double? Volume { get; set; } = DefaultVolume;
+        }
     }
 }

--- a/SettingsWindow.xaml
+++ b/SettingsWindow.xaml
@@ -1,21 +1,41 @@
-﻿<Window x:Class="HayChonGiaDung.Wpf.SettingsWindow"
+<Window x:Class="HayChonGiaDung.Wpf.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="SETTING" Height="320" Width="450"
+        Title="SETTING" Height="380" Width="500"
         WindowStartupLocation="CenterOwner"
         Background="{StaticResource Surface}">
-    <Border Background="SkyBlue" CornerRadius="12" Margin="16" Padding="20">
+    <Border Background="SkyBlue" CornerRadius="12" Margin="16" Padding="24">
         <StackPanel>
             <TextBlock Text="Âm Thanh" FontSize="28" FontWeight="Bold"
-                 Foreground="#C91C1C" HorizontalAlignment="Center" Margin="0,0,0,16"/>
+                       Foreground="#C91C1C" HorizontalAlignment="Center" Margin="0,0,0,16"/>
 
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" >
-                <RadioButton Foreground="Black" x:Name="RbOff" Content="Tắt" FontSize="20" Checked="RbOff_Checked"/>
-                <RadioButton  Foreground="Black" x:Name="RbOn"  Content="Bật" FontSize="20" Checked="RbOn_Checked"/>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,16">
+                <RadioButton Foreground="Black" x:Name="RbOff" Content="Tắt" FontSize="20"
+                             Checked="RbOff_Checked" Margin="0,0,20,0"/>
+                <RadioButton Foreground="Black" x:Name="RbOn" Content="Bật" FontSize="20"
+                             Checked="RbOn_Checked"/>
             </StackPanel>
 
-            <Button Content="Lưu" Width="120" Height="40" Margin="0,20,0,0"
-              HorizontalAlignment="Center" Click="Save_Click"/>
+            <StackPanel Margin="0,0,0,12">
+                <TextBlock Text="Âm lượng" FontSize="20" FontWeight="SemiBold" Foreground="#112D4E" Margin="0,0,0,6"/>
+                <Grid>
+                    <Slider x:Name="VolumeSlider" Minimum="0" Maximum="100" TickFrequency="10"
+                            IsSnapToTickEnabled="True" ValueChanged="VolumeSlider_ValueChanged"
+                            VerticalAlignment="Center" Height="36"/>
+                    <Border Background="#EEFFFFFF" CornerRadius="6" Padding="8,4" HorizontalAlignment="Right"
+                            Margin="0,0,6,0" VerticalAlignment="Center">
+                        <TextBlock x:Name="VolumeValueText" FontSize="16" FontWeight="Bold" Foreground="#112D4E"/>
+                    </Border>
+                </Grid>
+                <TextBlock Text="Kéo thanh trượt để điều chỉnh âm lượng nhạc nền và hiệu ứng." FontSize="14"
+                           Foreground="#102A43" TextWrapping="Wrap" Margin="0,6,0,0"/>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,12,0,0">
+                <Button x:Name="PreviewButton" Content="Nghe thử" Width="130" Height="40" Margin="0,0,16,0"
+                        Click="Preview_Click"/>
+                <Button Content="Lưu" Width="130" Height="40" Click="Save_Click"/>
+            </StackPanel>
         </StackPanel>
     </Border>
 </Window>

--- a/StartWindow.xaml.cs
+++ b/StartWindow.xaml.cs
@@ -9,7 +9,7 @@ namespace HayChonGiaDung.Wpf
         public StartWindow()
         {
             InitializeComponent();
-            SoundManager.StartBackground();
+            SettingsService.Load();
 
             // nếu không có file logo thì hiện fallback text
             try


### PR DESCRIPTION
## Summary
- redesign the settings window with clearer controls for toggling sound, adjusting volume, and previewing audio
- persist both mute state and master volume via SettingsService while applying updates immediately through SoundManager
- centralize audio configuration with master volume support and ensure the app loads saved settings on startup

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a9f432f48333bbee69fecd8543db