### PR TITLE
Add inline feedback notifications for quiz rounds

### DIFF
--- a/Round1Window.xaml
+++ b/Round1Window.xaml
@@ -51,8 +51,8 @@
                     <TextBlock x:Name="Question" FontSize="20" FontWeight="Bold" TextAlignment="Center" Margin="0,4,0,16"/>
 
                     <UniformGrid Columns="2" Rows="1" Margin="0,6,0,6">
-                        <Button Content="CAO HƠN" Height="70" FontSize="22" Click="Higher_Click" Margin="6"/>
-                        <Button Content="THẤP HƠN" Height="70" FontSize="22" Click="Lower_Click"  Margin="6"/>
+                        <Button x:Name="HigherButton" Content="CAO HƠN" Height="70" FontSize="22" Click="Higher_Click" Margin="6"/>
+                        <Button x:Name="LowerButton" Content="THẤP HƠN" Height="70" FontSize="22" Click="Lower_Click"  Margin="6"/>
                     </UniformGrid>
 
                     <TextBlock x:Name="Feedback" FontSize="18" TextAlignment="Center" Margin="0,10,0,0"/>

--- a/Round1Window.xaml.cs
+++ b/Round1Window.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media.Imaging;
 
@@ -85,8 +86,11 @@ namespace HayChonGiaDung.Wpf
             return "Chưa có mô tả cho sản phẩm này.";
         }
 
-        private void Evaluate(bool guessHigher)
+        private async Task EvaluateAsync(bool guessHigher)
         {
+            HigherButton.IsEnabled = false;
+            LowerButton.IsEnabled = false;
+
             bool isHigher = correctPrice > hiddenPrice;
             if (guessHigher == isHigher)
             {
@@ -100,11 +104,18 @@ namespace HayChonGiaDung.Wpf
                 SoundManager.Wrong();
             }
             CorrectCount.Text = $"{correct}/4";
+
+            await Task.Delay(1000);
+
+            Feedback.Text = string.Empty;
+            HigherButton.IsEnabled = true;
+            LowerButton.IsEnabled = true;
+
             NextQuestion();
         }
 
-        private void Higher_Click(object sender, RoutedEventArgs e) => Evaluate(true);
-        private void Lower_Click(object sender, RoutedEventArgs e) => Evaluate(false);
+        private async void Higher_Click(object sender, RoutedEventArgs e) => await EvaluateAsync(true);
+        private async void Lower_Click(object sender, RoutedEventArgs e) => await EvaluateAsync(false);
 
         private void Finish_Click(object sender, RoutedEventArgs e) => OpenPunchBoard();
 

--- a/Round3Window.xaml
+++ b/Round3Window.xaml
@@ -28,7 +28,10 @@
 
         <!-- Product grid -->
         <Border Grid.Row="1" Background="{StaticResource Card}" CornerRadius="18" Padding="18" Margin="0,14,0,14">
-            <UniformGrid x:Name="GridProducts" Rows="2" Columns="3" />
+            <StackPanel>
+                <UniformGrid x:Name="GridProducts" Rows="2" Columns="3" />
+                <TextBlock x:Name="Feedback" Margin="0,16,0,0" FontSize="18" TextAlignment="Center"/>
+            </StackPanel>
         </Border>
 
         <!-- Footer -->

--- a/Round3Window.xaml.cs
+++ b/Round3Window.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media.Imaging;
@@ -134,7 +135,7 @@ namespace HayChonGiaDung.Wpf
             }
         }
 
-        private void Pick(object sender, RoutedEventArgs e)
+        private async void Pick(object sender, RoutedEventArgs e)
         {
             if (picked) return; // chặn double click
             picked = true;
@@ -147,14 +148,16 @@ namespace HayChonGiaDung.Wpf
                 GameState.TotalPrize += 1_500_000;
                 PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
                 SoundManager.Correct();
-                MessageBox.Show("Chuẩn bài! +1.500.000 ₫", "Không Mà Có");
+                Feedback.Text = "✅ Chuẩn bài! +1.500.000 ₫";
+                await Task.Delay(1000);
                 this.DialogResult = true;
                 Close();
             }
             else
             {
                 SoundManager.Wrong();
-                MessageBox.Show("Sai mất rồi! Vòng này 0 ₫.", "Không Mà Có");
+                Feedback.Text = "❌ Sai mất rồi! Vòng này 0 ₫.";
+                await Task.Delay(1000);
                 this.DialogResult = false;
                 Close();
             }

--- a/Round4Window.xaml
+++ b/Round4Window.xaml
@@ -28,7 +28,10 @@
 
         <!-- Product trio -->
         <Border Grid.Row="1" Background="{StaticResource Card}" CornerRadius="18" Padding="18" Margin="0,14,0,14">
-            <UniformGrid x:Name="GridTrio" Rows="1" Columns="3"/>
+            <StackPanel>
+                <UniformGrid x:Name="GridTrio" Rows="1" Columns="3"/>
+                <TextBlock x:Name="Feedback" Margin="0,16,0,0" FontSize="18" TextAlignment="Center"/>
+            </StackPanel>
         </Border>
 
         <!-- Footer -->

--- a/Round4Window.xaml.cs
+++ b/Round4Window.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media.Imaging;
@@ -11,6 +12,7 @@ namespace HayChonGiaDung.Wpf
     {
         private int correctDisplayIndex;
         private Product[] trio = new Product[3];
+        private bool picked = false;
 
         public Round4Window()
         {
@@ -115,15 +117,19 @@ namespace HayChonGiaDung.Wpf
             return card;
         }
 
-        private void Pick(object sender, RoutedEventArgs e)
+        private async void Pick(object sender, RoutedEventArgs e)
         {
+            if (picked) return;
+            picked = true;
+
             int idx = (int)((Button)sender).Tag;
             if (idx == correctDisplayIndex)
             {
                 GameState.TotalPrize += 2_000_000;
                 PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
                 SoundManager.Correct();
-                MessageBox.Show("Quá thông minh! +2.000.000 ₫", "Lựa Chọn Thông Minh");
+                Feedback.Text = "✅ Quá thông minh! +2.000.000 ₫";
+                await Task.Delay(1000);
                 LeaderboardService.AddScore(GameState.PlayerName, GameState.TotalPrize);
                 this.DialogResult = true;
                 Close();
@@ -131,7 +137,8 @@ namespace HayChonGiaDung.Wpf
             else
             {
                 SoundManager.Wrong();
-                MessageBox.Show("Sai nước đi! Vòng này 0 ₫.", "Lựa Chọn Thông Minh");
+                Feedback.Text = "❌ Sai nước đi! Vòng này 0 ₫.";
+                await Task.Delay(1000);
                 LeaderboardService.AddScore(GameState.PlayerName, GameState.TotalPrize);
                 this.DialogResult = false;
                 Close();


### PR DESCRIPTION
## Summary
- show round 1 answer feedback inline for one second before moving to the next question
- replace message boxes in rounds 3 and 4 with inline feedback labels that disappear after a short delay
- prevent repeated clicks during feedback display to avoid multiple evaluations

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d4adbfd2088333bdfab2a7897a16ab