### PR TITLE
Fix leaderboard rank badge style triggers

### DIFF
--- a/LeaderboardWindow.xaml
+++ b/LeaderboardWindow.xaml
@@ -96,18 +96,20 @@
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">
                                                     <Setter Property="Visibility" Value="Collapsed" />
-                                                    <DataTrigger Binding="{Binding Rank}" Value="1">
-                                                        <Setter Property="Text" Value="🥇" />
-                                                        <Setter Property="Visibility" Value="Visible" />
-                                                    </DataTrigger>
-                                                    <DataTrigger Binding="{Binding Rank}" Value="2">
-                                                        <Setter Property="Text" Value="🥈" />
-                                                        <Setter Property="Visibility" Value="Visible" />
-                                                    </DataTrigger>
-                                                    <DataTrigger Binding="{Binding Rank}" Value="3">
-                                                        <Setter Property="Text" Value="🥉" />
-                                                        <Setter Property="Visibility" Value="Visible" />
-                                                    </DataTrigger>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Rank}" Value="1">
+                                                            <Setter Property="Text" Value="🥇" />
+                                                            <Setter Property="Visibility" Value="Visible" />
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding Rank}" Value="2">
+                                                            <Setter Property="Text" Value="🥈" />
+                                                            <Setter Property="Visibility" Value="Visible" />
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding Rank}" Value="3">
+                                                            <Setter Property="Text" Value="🥉" />
+                                                            <Setter Property="Visibility" Value="Visible" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
                                                 </Style>
                                             </TextBlock.Style>
                                         </TextBlock>


### PR DESCRIPTION
## Summary
- wrap the leaderboard rank TextBlock style triggers in a Style.Triggers section to avoid invalid DataTrigger placement

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b10ea9c48333ac18f1f61d1a58b8