### PR TITLE
Add strategic warmup, dynamic rounds, and final ordering challenge

### DIFF
--- a/GameState.cs
+++ b/GameState.cs
@@ -7,18 +7,89 @@ namespace HayChonGiaDung.Wpf
     {
         public static string PlayerName { get; set; } = "";
         public static int TotalPrize { get; set; } = 0;
+        public static int Coins { get; private set; }
         public static Random Rnd { get; } = new Random();
         public static List<Product> Catalog { get; private set; } = ProductRepository.LoadProducts();
+
+        private static readonly Dictionary<PowerCardType, int> _powerCards = new();
+        private static bool _doubleRewardQueued;
+
+        public static IReadOnlyDictionary<PowerCardType, int> PowerCards => _powerCards;
 
         public static void Reset()
         {
             TotalPrize = 0;
+            Coins = 0;
+            _powerCards.Clear();
+            _doubleRewardQueued = false;
         }
 
         public static void ReloadCatalog()
         {
             Catalog = ProductRepository.LoadProducts();
         }
+
+        public static void AddCoins(int amount)
+        {
+            if (amount <= 0) return;
+            Coins += amount;
+        }
+
+        public static bool TrySpendCoins(int amount)
+        {
+            if (amount <= 0) return true;
+            if (Coins < amount) return false;
+            Coins -= amount;
+            return true;
+        }
+
+        public static int GetCardCount(PowerCardType type)
+            => _powerCards.TryGetValue(type, out var count) ? count : 0;
+
+        public static void AddPowerCard(PowerCardType type, int amount = 1)
+        {
+            if (amount <= 0) return;
+            _powerCards[type] = GetCardCount(type) + amount;
+        }
+
+        public static bool TryUsePowerCard(PowerCardType type)
+        {
+            if (!_powerCards.TryGetValue(type, out var count) || count <= 0)
+            {
+                return false;
+            }
+
+            _powerCards[type] = count - 1;
+            return true;
+        }
+
+        public static void QueueDoubleReward()
+        {
+            _doubleRewardQueued = true;
+        }
+
+        public static void AddPrize(int amount)
+        {
+            if (amount <= 0) return;
+            if (_doubleRewardQueued)
+            {
+                amount *= 2;
+                _doubleRewardQueued = false;
+            }
+            TotalPrize += amount;
+        }
+
+        public static void CancelQueuedDouble()
+        {
+            _doubleRewardQueued = false;
+        }
+    }
+
+    public enum PowerCardType
+    {
+        Hint,
+        SwapProduct,
+        DoubleReward
     }
 
     public class Product

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -19,9 +19,15 @@
       </StackPanel>
     </Border>
 
-    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" >
-      <TextBlock Text="Tổng tiền thưởng:"/>
-      <TextBlock x:Name="PrizeText" FontWeight="Bold"/>
+    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+      <StackPanel Orientation="Horizontal" Margin="0,0,12,0">
+        <TextBlock Text="💰 Xu:"/>
+        <TextBlock x:Name="CoinText" FontWeight="Bold" Margin="4,0,0,0"/>
+      </StackPanel>
+      <StackPanel Orientation="Horizontal">
+        <TextBlock Text="Tổng tiền thưởng:"/>
+        <TextBlock x:Name="PrizeText" FontWeight="Bold" Margin="4,0,0,0"/>
+      </StackPanel>
     </StackPanel>
   </Grid>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -9,6 +9,7 @@ namespace HayChonGiaDung.Wpf
             InitializeComponent();
             this.WindowState = WindowState.Maximized;
             PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            CoinText.Text = GameState.Coins.ToString();
             //SoundManager.Background();
         }
 
@@ -21,24 +22,36 @@ namespace HayChonGiaDung.Wpf
             }
             GameState.PlayerName = PlayerNameBox.Text.Trim();
             GameState.Reset();
-            PrizeText.Text = "0 ₫";
+            UpdateEconomyTexts();
 
-            var r1 = new Round1Window();
-            r1.Owner = this;
+            var warmup = new QuickStartWindow { Owner = this };
+            if (warmup.ShowDialog() != true)
+            {
+                StatusText.Text = "Bạn đã dừng ở vòng khởi động.";
+                return;
+            }
+
+            StatusText.Text = string.Empty;
+            UpdateEconomyTexts();
+
+            var r1 = new Round1Window { Owner = this };
             r1.ShowDialog();
-            PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            UpdateEconomyTexts();
             if (HandleGameOver()) { return; }
 
-            var r2 = new Round2Window(); r2.Owner = this; r2.ShowDialog();
-            PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            var r2 = new Round2Window { Owner = this };
+            r2.ShowDialog();
+            UpdateEconomyTexts();
             if (HandleGameOver()) { return; }
 
-            var r3 = new Round3Window(); r3.Owner = this; r3.ShowDialog();
-            PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            var r3 = new Round3Window { Owner = this };
+            r3.ShowDialog();
+            UpdateEconomyTexts();
             if (HandleGameOver()) { return; }
 
-            var r4 = new Round4Window(); r4.Owner = this; r4.ShowDialog();
-            PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            var r4 = new Round4Window { Owner = this };
+            r4.ShowDialog();
+            UpdateEconomyTexts();
             if (HandleGameOver()) { return; }
 
             SoundManager.Win();
@@ -65,6 +78,12 @@ namespace HayChonGiaDung.Wpf
             startWindow.Show();
             Application.Current.MainWindow = startWindow;
             Close();
+        }
+
+        private void UpdateEconomyTexts()
+        {
+            PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            CoinText.Text = GameState.Coins.ToString();
         }
     }
 }

--- a/PunchBoardWindow.xaml.cs
+++ b/PunchBoardWindow.xaml.cs
@@ -38,7 +38,7 @@ namespace HayChonGiaDung.Wpf
             btn.Foreground = System.Windows.Media.Brushes.Black;
             btn.Background = prize>0 ? System.Windows.Media.Brushes.LightGreen : System.Windows.Media.Brushes.LightCoral;
             btn.Content = $"{prize:N0} ₫";
-            GameState.TotalPrize += prize;
+            GameState.AddPrize(prize);
             picksLeft--;
             LeftText.Text = picksLeft.ToString();
             if (prize>0) SoundManager.Correct(); else SoundManager.Wrong();

--- a/QuickStartWindow.xaml
+++ b/QuickStartWindow.xaml
@@ -1,0 +1,67 @@
+<Window x:Class="HayChonGiaDung.Wpf.QuickStartWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Khởi động nhanh"
+        WindowStartupLocation="CenterScreen"
+        WindowState="Maximized"
+        Background="{StaticResource Surface}">
+    <Grid Margin="24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <DockPanel>
+            <StackPanel Orientation="Vertical" DockPanel.Dock="Left">
+                <TextBlock Text="Vòng mở màn: Khởi động nhanh" FontSize="32" FontWeight="Bold"/>
+                <TextBlock x:Name="ProgressText" Opacity="0.85" Margin="0,6,0,0" FontSize="18"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center" Margin="12,0,0,0">
+                <TextBlock Text="💰 Xu hiện có:" FontSize="18"/>
+                <TextBlock x:Name="CoinText" FontSize="22" FontWeight="Bold" Margin="6,0,0,0"/>
+            </StackPanel>
+        </DockPanel>
+
+        <Border Grid.Row="1" Background="{StaticResource Card}" CornerRadius="20" Padding="28" Margin="0,18,0,18">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <TextBlock x:Name="QuestionText" FontSize="26" FontWeight="SemiBold" TextWrapping="Wrap"/>
+
+                <StackPanel Grid.Row="1" x:Name="OptionsPanel" Margin="0,18,0,18"/>
+
+                <StackPanel Grid.Row="2">
+                    <TextBlock x:Name="FeedbackText" FontSize="18" Margin="0,0,0,12"/>
+                    <Button x:Name="NextButton" Content="Câu tiếp theo" Width="200" Height="48" HorizontalAlignment="Right" Click="Next_Click" Visibility="Collapsed"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Thoát" Width="120" Click="Cancel_Click"/>
+        </StackPanel>
+
+        <Border x:Name="ShopPanel" Grid.RowSpan="3" Background="#BF000000" Visibility="Collapsed">
+            <Border Background="{StaticResource Card}" CornerRadius="20" Padding="28" HorizontalAlignment="Center" VerticalAlignment="Center" Width="600">
+                <StackPanel>
+                    <TextBlock Text="Tích lũy chiến thuật" FontSize="28" FontWeight="Bold" HorizontalAlignment="Center"/>
+                    <TextBlock Text="Dùng xu để mua thẻ hỗ trợ cho các vòng sau." Margin="0,8,0,18" TextAlignment="Center"/>
+
+                    <StackPanel Margin="0,12,0,0">
+                        <Button x:Name="BuyHintButton" Content="Mua thẻ Gợi ý (-5 xu)" Height="48" Click="BuyHint_Click" Margin="0,4,0,4"/>
+                        <Button x:Name="BuySwapButton" Content="Mua thẻ Đổi sản phẩm (-8 xu)" Height="48" Click="BuySwap_Click" Margin="0,4,0,4"/>
+                        <Button x:Name="BuyDoubleButton" Content="Mua thẻ Nhân đôi phần thưởng (-10 xu)" Height="48" Click="BuyDouble_Click" Margin="0,4,0,4"/>
+                    </StackPanel>
+
+                    <TextBlock x:Name="ShopStatus" Margin="0,12,0,0" FontSize="16" TextAlignment="Center"/>
+                    <Button Content="Sẵn sàng vào vòng chính" Margin="0,18,0,0" Height="50" Click="FinishShop_Click"/>
+                </StackPanel>
+            </Border>
+        </Border>
+    </Grid>
+</Window>

--- a/QuickStartWindow.xaml.cs
+++ b/QuickStartWindow.xaml.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+
+namespace HayChonGiaDung.Wpf
+{
+    public partial class QuickStartWindow : Window
+    {
+        private readonly List<QuickStartQuestion> _questions;
+        private int _index;
+        private int _correct;
+        private bool _awaitingNext;
+
+        public QuickStartWindow()
+        {
+            InitializeComponent();
+            WindowState = WindowState.Maximized;
+
+            _questions = BuildQuestions().OrderBy(_ => GameState.Rnd.Next()).Take(6).ToList();
+            SoundManager.StartRound();
+            UpdateCoins();
+            LoadQuestion();
+        }
+
+        private static IEnumerable<QuickStartQuestion> BuildQuestions()
+        {
+            yield return new QuickStartQuestion("Thiết bị nào thường được dán nhãn năng lượng để người tiêu dùng nhận biết mức tiết kiệm điện?",
+                new[] { "Máy điều hòa", "Máy in", "Bàn ủi hơi nước", "Nồi cơm điện" }, 0);
+            yield return new QuickStartQuestion("Chất liệu nào giúp chảo chống dính bền hơn khi sử dụng với nhiệt cao?",
+                new[] { "Hợp kim nhôm phủ gốm", "Inox 201", "Gang thô không xử lý", "Nhựa ABS" }, 0);
+            yield return new QuickStartQuestion("Khi mua máy lọc không khí cho phòng ngủ 20m², thông số CADR tối thiểu nên khoảng bao nhiêu?",
+                new[] { "150 m³/h", "60 m³/h", "320 m³/h", "45 m³/h" }, 0);
+            yield return new QuickStartQuestion("Tiêu chuẩn an toàn nào thường thấy trên ổ cắm kéo dài chất lượng?",
+                new[] { "Chứng nhận QCVN 4:2009/BKHCN", "Tem hợp quy đồ chơi", "Ký hiệu IP68", "Tem chống hàng giả" }, 0);
+            yield return new QuickStartQuestion("Tủ lạnh Inverter mang lại lợi ích chính nào?",
+                new[] { "Tiết kiệm điện và vận hành êm", "Giá rẻ hơn tủ thường", "Rã đông nhanh hơn", "Dung tích lớn hơn" }, 0);
+            yield return new QuickStartQuestion("Khi chọn robot hút bụi cho nhà nhiều tầng, phụ kiện nào là quan trọng nhất?",
+                new[] { "Cảm biến chống rơi", "Đèn UV", "Túi lọc nước", "Chổi cao su" }, 0);
+            yield return new QuickStartQuestion("Dung tích bình chứa bụi của máy hút cầm tay nên tối thiểu bao nhiêu để tránh đổ liên tục?",
+                new[] { "0.4 lít", "0.05 lít", "1.5 lít", "3 lít" }, 0);
+            yield return new QuickStartQuestion("Trên máy lọc nước RO, lõi than hoạt tính có tác dụng gì?",
+                new[] { "Khử mùi và cải thiện vị", "Diệt khuẩn bằng tia UV", "Bổ sung khoáng tức thì", "Ổn định áp lực nước" }, 0);
+            yield return new QuickStartQuestion("Khi bảo quản nồi chảo chống dính, thao tác nào nên tránh?",
+                new[] { "Dùng miếng chà kim loại", "Phơi khô tự nhiên", "Để nguội trước khi rửa", "Sử dụng muỗng silicon" }, 0);
+            yield return new QuickStartQuestion("Tiêu chí nào KHÔNG thuộc chương trình Nhãn năng lượng Việt Nam?",
+                new[] { "Mức phát thải CO2", "Hiệu suất năng lượng", "Chỉ số tiêu thụ điện", "Số sao hiệu suất" }, 0);
+            yield return new QuickStartQuestion("Công nghệ nào giúp máy giặt giảm nhăn áo quần sau khi giặt?",
+                new[] { "Giặt hơi nước", "Sấy không khí", "Sấy nóng liên tục", "Tạo bọt khí lạnh" }, 0);
+        }
+
+        private void LoadQuestion()
+        {
+            if (_index >= _questions.Count)
+            {
+                ShowShop();
+                return;
+            }
+
+            _awaitingNext = false;
+            var q = _questions[_index];
+            ProgressText.Text = $"Câu {_index + 1}/{_questions.Count}";
+            QuestionText.Text = q.Question;
+            FeedbackText.Text = string.Empty;
+            NextButton.Visibility = Visibility.Collapsed;
+
+            OptionsPanel.Children.Clear();
+            int i = 0;
+            foreach (var option in q.Options)
+            {
+                var btn = new Button
+                {
+                    Content = option,
+                    Tag = i,
+                    Height = 54,
+                    Margin = new Thickness(0, 6, 0, 6),
+                    FontSize = 18,
+                    HorizontalContentAlignment = HorizontalAlignment.Left
+                };
+                btn.Click += Option_Click;
+                OptionsPanel.Children.Add(btn);
+                i++;
+            }
+
+            SoundManager.Reveal();
+            AnimatePanel(OptionsPanel);
+        }
+
+        private void Option_Click(object sender, RoutedEventArgs e)
+        {
+            if (_awaitingNext) return;
+
+            _awaitingNext = true;
+            var btn = (Button)sender;
+            int guess = (int)btn.Tag;
+            var q = _questions[_index];
+
+            foreach (Button child in OptionsPanel.Children)
+            {
+                child.IsEnabled = false;
+                child.Background = Brushes.Transparent;
+            }
+
+            if (guess == q.CorrectIndex)
+            {
+                _correct++;
+                GameState.AddCoins(5);
+                btn.Background = Brushes.LightGreen;
+                FeedbackText.Text = "✅ Chính xác! +5 xu";
+                SoundManager.Correct();
+            }
+            else
+            {
+                btn.Background = Brushes.LightCoral;
+                var correctBtn = OptionsPanel.Children.Cast<Button>().First(b => (int)b.Tag == q.CorrectIndex);
+                correctBtn.Background = Brushes.LightGreen;
+                FeedbackText.Text = "❌ Chưa đúng. Hãy ghi nhớ kiến thức này!";
+                SoundManager.Wrong();
+            }
+
+            UpdateCoins();
+            NextButton.Visibility = Visibility.Visible;
+        }
+
+        private void Next_Click(object sender, RoutedEventArgs e)
+        {
+            _index++;
+            LoadQuestion();
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+
+        private void ShowShop()
+        {
+            ProgressText.Text = $"Hoàn thành {_correct}/{_questions.Count} câu";
+            QuestionText.Text = "Bạn đã sẵn sàng bước vào chương trình chính!";
+            OptionsPanel.Children.Clear();
+            FeedbackText.Text = "Hãy dùng xu để mua thẻ chiến thuật phù hợp.";
+            NextButton.Visibility = Visibility.Collapsed;
+            UpdateCoins();
+            UpdateShopButtons();
+            ShopStatus.Text = $"Đã trả lời đúng {_correct} câu, tích lũy {GameState.Coins} xu.";
+            ShopPanel.Visibility = Visibility.Visible;
+        }
+
+        private void UpdateShopButtons()
+        {
+            BuyHintButton.Content = $"Mua thẻ Gợi ý (-5 xu) — hiện có {GameState.GetCardCount(PowerCardType.Hint)}";
+            BuySwapButton.Content = $"Mua thẻ Đổi sản phẩm (-8 xu) — hiện có {GameState.GetCardCount(PowerCardType.SwapProduct)}";
+            BuyDoubleButton.Content = $"Mua thẻ Nhân đôi phần thưởng (-10 xu) — hiện có {GameState.GetCardCount(PowerCardType.DoubleReward)}";
+        }
+
+        private void BuyHint_Click(object sender, RoutedEventArgs e) => BuyCard(PowerCardType.Hint, 5);
+        private void BuySwap_Click(object sender, RoutedEventArgs e) => BuyCard(PowerCardType.SwapProduct, 8);
+        private void BuyDouble_Click(object sender, RoutedEventArgs e) => BuyCard(PowerCardType.DoubleReward, 10);
+
+        private void BuyCard(PowerCardType type, int cost)
+        {
+            if (!GameState.TrySpendCoins(cost))
+            {
+                ShopStatus.Text = "⚠️ Không đủ xu để mua thẻ này.";
+                SoundManager.Wrong();
+                return;
+            }
+
+            GameState.AddPowerCard(type);
+            ShopStatus.Text = "Đã mua thẻ thành công!";
+            SoundManager.Correct();
+            UpdateCoins();
+            UpdateShopButtons();
+        }
+
+        private void FinishShop_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            Close();
+        }
+
+        private void UpdateCoins()
+        {
+            CoinText.Text = GameState.Coins.ToString();
+        }
+
+        private static void AnimatePanel(Panel panel)
+        {
+            var sb = new Storyboard();
+            var fade = new DoubleAnimation(0, 1, new Duration(TimeSpan.FromMilliseconds(400)));
+            Storyboard.SetTarget(fade, panel);
+            Storyboard.SetTargetProperty(fade, new PropertyPath(UIElement.OpacityProperty));
+            sb.Children.Add(fade);
+            panel.Opacity = 0;
+            sb.Begin();
+        }
+    }
+
+    internal record QuickStartQuestion(string Question, IReadOnlyList<string> Options, int CorrectIndex);
+}

--- a/Round1Window.xaml
+++ b/Round1Window.xaml
@@ -4,6 +4,20 @@
         Title="Vòng 1 - Bàn Tay Vàng"
         WindowState="Maximized"
         Background="{StaticResource Surface}">
+    <Window.Resources>
+        <Storyboard x:Key="RevealStoryboard">
+            <DoubleAnimation To="1" Duration="0:0:0.45"
+                             Storyboard.TargetProperty="RenderTransform.(ScaleTransform.ScaleX)"
+                             From="0.8"/>
+            <DoubleAnimation To="1" Duration="0:0:0.45"
+                             Storyboard.TargetProperty="RenderTransform.(ScaleTransform.ScaleY)"
+                             From="0.8"/>
+            <DoubleAnimation To="1" Duration="0:0:0.45"
+                             Storyboard.TargetProperty="Opacity"
+                             From="0"/>
+        </Storyboard>
+    </Window.Resources>
+
     <Grid Margin="24">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -19,8 +33,18 @@
             </StackPanel>
 
             <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
-                <TextBlock Text="Đúng:"/>
-                <TextBlock x:Name="CorrectCount" FontWeight="Bold"/>
+                <StackPanel Orientation="Horizontal" Margin="0,0,12,0">
+                    <TextBlock Text="💰 Xu:"/>
+                    <TextBlock x:Name="CoinText" FontWeight="Bold" Margin="4,0,0,0"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,0,12,0">
+                    <TextBlock Text="Thẻ:"/>
+                    <TextBlock x:Name="CardText" FontWeight="Bold" Margin="4,0,0,0"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="Đúng:"/>
+                    <TextBlock x:Name="CorrectCount" FontWeight="Bold" Margin="4,0,0,0"/>
+                </StackPanel>
             </StackPanel>
         </DockPanel>
 
@@ -41,21 +65,33 @@
                     </ScrollViewer>
 
                     <Border CornerRadius="12" Background="#121C3C" Padding="10" Margin="0,12,0,0">
-                        <Image x:Name="ProductImage" Height="280" Stretch="Uniform"/>
+                        <Image x:Name="ProductImage" Height="280" Stretch="Uniform" RenderTransformOrigin="0.5,0.5">
+                            <Image.RenderTransform>
+                                <ScaleTransform ScaleX="1" ScaleY="1"/>
+                            </Image.RenderTransform>
+                        </Image>
                     </Border>
                 </StackPanel>
 
                 <!-- RIGHT: question & actions -->
                 <StackPanel Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center" Width="520">
-                    <TextBlock Text="GIÁ ẨN" FontSize="18" Opacity="0.8" HorizontalAlignment="Center"/>
+                    <TextBlock Text="ĐOÁN GIÁ TRONG PHẠM VI ±10%" FontSize="18" Opacity="0.8" HorizontalAlignment="Center"/>
                     <TextBlock x:Name="Question" FontSize="20" FontWeight="Bold" TextAlignment="Center" Margin="0,4,0,16"/>
 
-                    <UniformGrid Columns="2" Rows="1" Margin="0,6,0,6">
-                        <Button x:Name="HigherButton" Content="CAO HƠN" Height="70" FontSize="22" Click="Higher_Click" Margin="6"/>
-                        <Button x:Name="LowerButton" Content="THẤP HƠN" Height="70" FontSize="22" Click="Lower_Click"  Margin="6"/>
+                    <TextBox x:Name="PriceGuessBox" Height="60" FontSize="22" Margin="0,0,0,12" HorizontalContentAlignment="Center"/>
+                    <Button x:Name="SubmitButton" Content="Khóa đáp án" Height="60" FontSize="20" Click="Submit_Click"/>
+
+                    <TextBlock x:Name="RangeHint" FontSize="18" TextAlignment="Center" Margin="0,12,0,6"/>
+
+                    <Separator Margin="0,6,0,6"/>
+                    <TextBlock Text="Thẻ chiến thuật" FontWeight="Bold" HorizontalAlignment="Center"/>
+                    <UniformGrid Columns="3" Margin="0,8,0,0">
+                        <Button x:Name="HintButton" Content="Gợi ý (-5 xu)" Margin="4" Click="HintButton_Click"/>
+                        <Button x:Name="SwapButton" Content="Đổi sản phẩm (-8 xu)" Margin="4" Click="SwapButton_Click"/>
+                        <Button x:Name="DoubleButton" Content="Nhân đôi thưởng (-10 xu)" Margin="4" Click="DoubleButton_Click"/>
                     </UniformGrid>
 
-                    <TextBlock x:Name="Feedback" FontSize="18" TextAlignment="Center" Margin="0,10,0,0"/>
+                    <TextBlock x:Name="Feedback" FontSize="18" TextAlignment="Center" Margin="0,16,0,0"/>
                 </StackPanel>
             </Grid>
         </Border>

--- a/Round2Window.xaml
+++ b/Round2Window.xaml
@@ -1,53 +1,56 @@
 <Window x:Class="HayChonGiaDung.Wpf.Round2Window"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Vòng 2 - Đếm Ngược"
+        Title="Vòng 2 - So Tài Nhóm Giá"
         WindowState="Maximized"
         Background="{StaticResource Surface}">
+
+    <Window.Resources>
+        <Storyboard x:Key="CardRevealStoryboard">
+            <DoubleAnimation To="1" Duration="0:0:0.35"
+                             Storyboard.TargetProperty="Opacity"
+                             From="0"/>
+        </Storyboard>
+    </Window.Resources>
+
     <Grid Margin="20">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <!-- Header -->
         <DockPanel Grid.Row="0">
-            <TextBlock Text="Vòng 2: Đếm Ngược" FontSize="28" FontWeight="Bold" DockPanel.Dock="Left"/>
+            <StackPanel Orientation="Vertical" DockPanel.Dock="Left">
+                <TextBlock Text="Vòng 2: So Tài Nhóm Giá" FontSize="30" FontWeight="Bold"/>
+                <TextBlock x:Name="InstructionText" Opacity="0.85" Margin="0,4,0,0"/>
+            </StackPanel>
             <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
-                <TextBlock Text="⏳ Thời gian:" FontSize="18" Margin="0,0,8,0"/>
-                <TextBlock x:Name="TimerText" FontSize="22" FontWeight="Bold"/>
+                <StackPanel Orientation="Horizontal" Margin="0,0,12,0">
+                    <TextBlock Text="💰 Xu:"/>
+                    <TextBlock x:Name="CoinText" FontWeight="Bold" Margin="4,0,0,0"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="Thẻ:"/>
+                    <TextBlock x:Name="CardText" FontWeight="Bold" Margin="4,0,0,0"/>
+                </StackPanel>
             </StackPanel>
         </DockPanel>
 
         <!-- Main content -->
-        <Border Grid.Row="1" Background="{StaticResource Card}" CornerRadius="16" Padding="20" Margin="0,12">
-            <StackPanel HorizontalAlignment="Center">
-
-                <!-- Product Name -->
-                <TextBlock x:Name="ProductName" FontSize="22" FontWeight="SemiBold" TextAlignment="Center"/>
-
-                <!-- Product Image -->
-                <Image x:Name="ProductImage" Height="220" Stretch="Uniform" Margin="0,12"/>
-
-                <!-- Input boxes -->
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,16">
-                    <TextBox x:Name="D1" Width="70" Height="70" FontSize="28" MaxLength="1"
-                   HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="4"/>
-                    <TextBox x:Name="D2" Width="70" Height="70" FontSize="28" MaxLength="1"
-                   HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="4"/>
-                    <TextBox x:Name="D3" Width="70" Height="70" FontSize="28" MaxLength="1"
-                   HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="4"/>
-                    <TextBox x:Name="D4" Width="70" Height="70" FontSize="28" MaxLength="1"
-                   HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="4"/>
-                </StackPanel>
-
-                <!-- Check button -->
-                <Button Content="Kiểm tra" Width="140" Height="45" FontSize="18" Click="Check_Click"/>
-
-                <!-- Hint -->
-                <TextBlock x:Name="Hint" FontSize="18" Margin="0,14,0,0" TextAlignment="Center"/>
+        <Border Grid.Row="1" Background="{StaticResource Card}" CornerRadius="16" Padding="24" Margin="0,18">
+            <StackPanel>
+                <UniformGrid x:Name="ProductPanel" Columns="2" Rows="2"/>
+                <TextBlock x:Name="Feedback" FontSize="18" TextAlignment="Center" Margin="0,16,0,0"/>
             </StackPanel>
         </Border>
 
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="HintButton" Content="Gợi ý (-5 xu)" Margin="4" Click="HintButton_Click"/>
+            <Button x:Name="SwapButton" Content="Đổi nhóm (-8 xu)" Margin="4" Click="SwapButton_Click"/>
+            <Button x:Name="DoubleButton" Content="Nhân đôi thưởng (-10 xu)" Margin="4" Click="DoubleButton_Click"/>
+            <Button Content="Thoát vòng" Margin="12,0,0,0" Click="Cancel_Click"/>
+        </StackPanel>
     </Grid>
 </Window>

--- a/Round2Window.xaml.cs
+++ b/Round2Window.xaml.cs
@@ -1,109 +1,295 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
-using System.Windows.Threading;
 
 namespace HayChonGiaDung.Wpf
 {
     public partial class Round2Window : Window
     {
-        private Product current = null!;
-        private int price4;            // giá tính theo nghìn
-        private int timeLeft = 60;     // 60 giây
-        private DispatcherTimer timer;
+        private readonly List<Border> _cards = new();
+        private Product[] _group = Array.Empty<Product>();
+        private int _targetIndex;
+        private bool _findHighest;
+        private bool _hintUsed;
+        private bool _locked;
 
         public Round2Window()
         {
             InitializeComponent();
             this.WindowState = WindowState.Maximized;
             SoundManager.StartRound();
-
-            // Random sản phẩm
-            current = GameState.Catalog.Count > 0
-                ? GameState.Catalog[GameState.Rnd.Next(GameState.Catalog.Count)]
-                : new Product { Name = "Sản phẩm demo", Price = 2_890_000, Image = null };
-
-            ProductName.Text = $"Đoán 4 chữ số cho giá (x.000 ₫): {current.Name}";
-            price4 = Math.Max(1000, current.Price) / 1000;
-
-            ProductImage.Source = null;
-            if (!string.IsNullOrWhiteSpace(current.ImageUrl) &&
-                Uri.IsWellFormedUriString(current.ImageUrl, UriKind.Absolute))
-            {
-                ProductImage.Source = new BitmapImage(new Uri(current.ImageUrl));
-            }
-            else if (!string.IsNullOrWhiteSpace(current.Image))
-            {
-                string path = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets", "Images", current.Image);
-                if (System.IO.File.Exists(path))
-                    ProductImage.Source = new BitmapImage(new Uri(path));
-            }
-
-            // Khởi tạo timer
-            TimerText.Text = timeLeft.ToString();
-            timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
-            timer.Tick += Timer_Tick;
-            timer.Start();
+            RefreshHud();
+            GenerateRound();
         }
 
-        private void Timer_Tick(object? sender, EventArgs e)
+        private void GenerateRound()
         {
-            timeLeft--;
-            TimerText.Text = timeLeft.ToString();
+            _locked = false;
+            _hintUsed = false;
+            _findHighest = GameState.Rnd.Next(2) == 0;
+            InstructionText.Text = _findHighest
+                ? "Chọn sản phẩm có giá CAO NHẤT trong nhóm."
+                : "Chọn sản phẩm có giá THẤP NHẤT trong nhóm.";
 
-            if (timeLeft <= 0)
+            _group = GameState.Catalog.OrderBy(_ => GameState.Rnd.Next()).Take(4).ToArray();
+            if (_group.Length < 4)
             {
-                timer.Stop();
-                SoundManager.Wrong();
-                MessageBox.Show("⏰ Hết giờ! Bạn đã thua vòng Đếm Ngược");
-                this.DialogResult = false;
-                Close();
+                _group = new[]
+                {
+                    new Product{ Name="Lò vi sóng", Price=1_600_000, Description="Mẫu tham chiếu."},
+                    new Product{ Name="Bàn ủi hơi nước", Price=950_000, Description="Mẫu tham chiếu."},
+                    new Product{ Name="Tủ lạnh 300L", Price=9_500_000, Description="Mẫu tham chiếu."},
+                    new Product{ Name="Máy hút bụi", Price=3_200_000, Description="Mẫu tham chiếu."}
+                };
             }
+
+            _targetIndex = _findHighest
+                ? Array.IndexOf(_group, _group.OrderBy(p => p.Price).Last())
+                : Array.IndexOf(_group, _group.OrderBy(p => p.Price).First());
+
+            RenderCards();
+            Feedback.Text = string.Empty;
         }
 
-        private void Check_Click(object sender, RoutedEventArgs e)
+        private void RenderCards()
         {
-            string g = $"{D1.Text}{D2.Text}{D3.Text}{D4.Text}";
-            if (g.Length != 4 || !int.TryParse(g, out var guess))
+            ProductPanel.Children.Clear();
+            _cards.Clear();
+
+            for (int i = 0; i < _group.Length; i++)
             {
-                Hint.Text = "⚠️ Nhập đủ 4 chữ số (0-9).";
-                return;
+                var p = _group[i];
+                var card = new Border
+                {
+                    CornerRadius = new CornerRadius(16),
+                    BorderThickness = new Thickness(1),
+                    BorderBrush = Brushes.Transparent,
+                    Margin = new Thickness(12),
+                    Padding = new Thickness(12),
+                    Background = Brushes.White,
+                    Opacity = 0
+                };
+
+                var stack = new StackPanel();
+
+                var img = new Image { Height = 160, Stretch = Stretch.UniformToFill, Margin = new Thickness(0, 0, 0, 8) };
+                if (!string.IsNullOrWhiteSpace(p.ImageUrl) && Uri.IsWellFormedUriString(p.ImageUrl, UriKind.Absolute))
+                {
+                    img.Source = new BitmapImage(new Uri(p.ImageUrl));
+                }
+                else if (!string.IsNullOrWhiteSpace(p.Image))
+                {
+                    string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets", "Images", p.Image);
+                    if (File.Exists(path))
+                        img.Source = new BitmapImage(new Uri(path));
+                }
+
+                var name = new TextBlock
+                {
+                    Text = p.Name,
+                    FontWeight = FontWeights.Bold,
+                    FontSize = 18,
+                    TextWrapping = TextWrapping.Wrap
+                };
+
+                var desc = new TextBlock
+                {
+                    Text = string.IsNullOrWhiteSpace(p.Description) ? "Sản phẩm thuộc danh mục gia dụng." : p.Description,
+                    TextWrapping = TextWrapping.Wrap,
+                    Margin = new Thickness(0, 6, 0, 6),
+                    Opacity = 0.75
+                };
+
+                var btn = new Button
+                {
+                    Content = "Chọn sản phẩm này",
+                    Margin = new Thickness(0, 8, 0, 0),
+                    Tag = i
+                };
+                btn.Click += Pick;
+
+                stack.Children.Add(img);
+                stack.Children.Add(name);
+                stack.Children.Add(desc);
+                stack.Children.Add(btn);
+
+                card.Child = stack;
+                ProductPanel.Children.Add(card);
+                _cards.Add(card);
+
+                AnimateCard(card);
             }
 
-            int target = price4;
-            if (guess == target)
+            SoundManager.Reveal();
+        }
+
+        private async void Pick(object sender, RoutedEventArgs e)
+        {
+            if (_locked) return;
+            _locked = true;
+
+            var btn = (Button)sender;
+            int pickIndex = (int)btn.Tag;
+
+            foreach (var button in ProductPanel.Children.OfType<Border>().SelectMany(b => b.Child is StackPanel sp ? sp.Children.OfType<Button>() : Array.Empty<Button>()))
             {
-                timer.Stop();
-                Hint.Text = $"✅ Chính xác! Giá: {target:N0}.000 ₫ (+1,000,000 ₫)";
-                GameState.TotalPrize += 1_000_000;
+                button.IsEnabled = false;
+            }
+
+            var targetProduct = _group[_targetIndex];
+            bool correct = pickIndex == _targetIndex;
+            HighlightResult(pickIndex, correct);
+
+            if (correct)
+            {
+                GameState.AddPrize(1_200_000);
+                Feedback.Text = $"✅ Chuẩn! {targetProduct.Name} có giá {targetProduct.Price:N0} ₫ (+1.200.000 ₫)";
                 SoundManager.Correct();
-                this.DialogResult = true;
-                Close();
+            }
+            else
+            {
+                var chosen = _group[pickIndex];
+                Feedback.Text = $"❌ Chưa đúng. {targetProduct.Name} mới là đáp án ({targetProduct.Price:N0} ₫). Bạn chọn {chosen.Name} ({chosen.Price:N0} ₫).";
+                SoundManager.Wrong();
+            }
+
+            RefreshHud();
+            await Task.Delay(1500);
+            DialogResult = correct;
+            Close();
+        }
+
+        private void HighlightResult(int pickedIndex, bool success)
+        {
+            for (int i = 0; i < _cards.Count; i++)
+            {
+                var brush = Brushes.Transparent;
+                if (i == _targetIndex)
+                {
+                    brush = Brushes.LimeGreen;
+                }
+                else if (i == pickedIndex && !success)
+                {
+                    brush = Brushes.IndianRed;
+                }
+
+                _cards[i].BorderBrush = brush;
+                _cards[i].BorderThickness = new Thickness(3);
+            }
+        }
+
+        private void HintButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_hintUsed)
+            {
+                Feedback.Text = "Bạn đã dùng gợi ý cho lượt này.";
                 return;
             }
 
-            // Gợi ý từng digit để đoán tiếp trong 60s (so sánh theo int)
-            var gt = target.ToString("0000");     // giữ leading zero
-            char[] hint = new char[4];
+            if (!EnsureCardAvailable(PowerCardType.Hint, 5, "Gợi ý"))
+                return;
 
-            for (int i = 0; i < 4; i++)
+            _hintUsed = true;
+            var highlight = new HashSet<int> { _targetIndex };
+            while (highlight.Count < 2)
             {
-                int gd = g[i] - '0';             // char -> int (0..9)
-                int td = gt[i] - '0';             // char -> int (0..9)
-
-                hint[i] = (gd == td) ? '='
-                       : (gd < td) ? '<'
-                                     : '>';
+                int idx = GameState.Rnd.Next(_group.Length);
+                highlight.Add(idx);
             }
 
-            Hint.Text = $"Gợi ý: [{hint[0]} {hint[1]} {hint[2]} {hint[3]}]";
+            foreach (var index in highlight)
+            {
+                _cards[index].Background = new SolidColorBrush(Color.FromArgb(40, 255, 215, 0));
+            }
 
-            SoundManager.Wrong();
+            Feedback.Text = "Một trong các thẻ được tô sáng là đáp án!";
+            RefreshHud();
+        }
 
-            // (optional) Auto-focus lại ô đầu để gõ nhanh vòng sau:
-            D1.Focus();
-            D1.SelectAll();
+        private void SwapButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (!EnsureCardAvailable(PowerCardType.SwapProduct, 8, "Đổi nhóm"))
+                return;
+
+            Feedback.Text = "Đã đổi sang bộ sản phẩm mới.";
+            RefreshHud();
+            GenerateRound();
+        }
+
+        private void DoubleButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (!EnsureCardAvailable(PowerCardType.DoubleReward, 10, "Nhân đôi"))
+                return;
+
+            GameState.QueueDoubleReward();
+            Feedback.Text = "⭐ Thẻ nhân đôi đã sẵn sàng cho phần thưởng tiếp theo.";
+            RefreshHud();
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+
+        private void RefreshHud()
+        {
+            CoinText.Text = GameState.Coins.ToString();
+            CardText.Text = $"Gợi ý {GameState.GetCardCount(PowerCardType.Hint)} • Đổi {GameState.GetCardCount(PowerCardType.SwapProduct)} • x2 {GameState.GetCardCount(PowerCardType.DoubleReward)}";
+        }
+
+        private bool EnsureCardAvailable(PowerCardType type, int coinCost, string cardLabel)
+        {
+            if (GameState.TryUsePowerCard(type))
+            {
+                return true;
+            }
+
+            if (GameState.Coins < coinCost)
+            {
+                MessageBox.Show("Bạn không còn thẻ và cũng không đủ xu để mua thêm.", cardLabel, MessageBoxButton.OK, MessageBoxImage.Information);
+                return false;
+            }
+
+            var confirm = MessageBox.Show($"Mua thẻ {cardLabel} với {coinCost} xu?", "Mua thẻ", MessageBoxButton.YesNo, MessageBoxImage.Question);
+            if (confirm != MessageBoxResult.Yes)
+            {
+                return false;
+            }
+
+            if (!GameState.TrySpendCoins(coinCost))
+            {
+                MessageBox.Show("Xu hiện có không đủ.", "Thông báo", MessageBoxButton.OK, MessageBoxImage.Information);
+                return false;
+            }
+
+            GameState.AddPowerCard(type);
+            GameState.TryUsePowerCard(type);
+            RefreshHud();
+            return true;
+        }
+
+        private void AnimateCard(Border card)
+        {
+            try
+            {
+                if (FindResource("CardRevealStoryboard") is Storyboard storyboard)
+                {
+                    var sb = storyboard.Clone();
+                    foreach (var anim in sb.Children)
+                    {
+                        Storyboard.SetTarget(anim, card);
+                    }
+                    sb.Begin();
+                }
+            }
+            catch { /* ignore animation errors */ }
         }
     }
 }

--- a/Round3Window.xaml
+++ b/Round3Window.xaml
@@ -16,13 +16,23 @@
         <DockPanel Grid.Row="0">
             <StackPanel Orientation="Vertical" DockPanel.Dock="Left">
                 <TextBlock Text="Vòng 3: Không Mà Có" FontSize="30" FontWeight="Bold"/>
-                <TextBlock Text="Chọn sản phẩm có GIÁ KHÔNG HỢP LÝ so với các sản phẩm còn lại." 
+                <TextBlock Text="Chọn sản phẩm có GIÁ KHÔNG HỢP LÝ so với các sản phẩm còn lại."
                    Opacity="0.8" Margin="0,4,0,0"/>
             </StackPanel>
 
             <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
-                <TextBlock Text="Tổng thưởng:" FontSize="18" Margin="0,0,8,0"/>
-                <TextBlock x:Name="PrizeText" FontSize="22" FontWeight="Bold"/>
+                <StackPanel Orientation="Horizontal" Margin="0,0,12,0">
+                    <TextBlock Text="💰 Xu:"/>
+                    <TextBlock x:Name="CoinText" FontWeight="Bold" Margin="4,0,0,0"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,0,12,0">
+                    <TextBlock Text="Thẻ:"/>
+                    <TextBlock x:Name="CardText" FontWeight="Bold" Margin="4,0,0,0"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="Tổng thưởng:" FontSize="18" Margin="0,0,8,0"/>
+                    <TextBlock x:Name="PrizeText" FontSize="22" FontWeight="Bold"/>
+                </StackPanel>
             </StackPanel>
         </DockPanel>
 
@@ -30,6 +40,11 @@
         <Border Grid.Row="1" Background="{StaticResource Card}" CornerRadius="18" Padding="18" Margin="0,14,0,14">
             <StackPanel>
                 <UniformGrid x:Name="GridProducts" Rows="2" Columns="3" />
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,12,0,0">
+                    <Button x:Name="HintButton" Content="Gợi ý (-5 xu)" Margin="4" Click="HintButton_Click"/>
+                    <Button x:Name="SwapButton" Content="Đổi bộ (-8 xu)" Margin="4" Click="SwapButton_Click"/>
+                    <Button x:Name="DoubleButton" Content="Nhân đôi (-10 xu)" Margin="4" Click="DoubleButton_Click"/>
+                </StackPanel>
                 <TextBlock x:Name="Feedback" Margin="0,16,0,0" FontSize="18" TextAlignment="Center"/>
             </StackPanel>
         </Border>

--- a/Round3Window.xaml.cs
+++ b/Round3Window.xaml.cs
@@ -1,19 +1,24 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
 
 namespace HayChonGiaDung.Wpf
 {
     public partial class Round3Window : Window
     {
+        private readonly List<Border> _cards = new();
         private int fakeIndex;
         private Product[] group = new Product[6];
         private int[] displayPrices = new int[6];
-        private bool picked = false;
+        private bool picked;
+        private bool hintUsed;
 
         public Round3Window()
         {
@@ -21,36 +26,40 @@ namespace HayChonGiaDung.Wpf
             SoundManager.StartRound();
 
             PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            RefreshHud();
+            GenerateRound();
+        }
 
-            // Lấy 6 sản phẩm ngẫu nhiên (unique)
+        private void GenerateRound()
+        {
+            picked = false;
+            hintUsed = false;
+            Feedback.Text = string.Empty;
+
             var pool = GameState.Catalog.OrderBy(_ => GameState.Rnd.Next()).Take(6).ToArray();
             if (pool.Length < 6)
             {
-                // fallback nếu ít data
                 pool = new[]
                 {
-                    new Product{ Name="SP A", Price=8500000 },
-                    new Product{ Name="SP B", Price=9200000 },
-                    new Product{ Name="SP C", Price=7800000 },
-                    new Product{ Name="SP D", Price=8100000 },
-                    new Product{ Name="SP E", Price=7900000 },
-                    new Product{ Name="SP F", Price=8000000 }
+                    new Product{ Name="SP A", Price=8_500_000 },
+                    new Product{ Name="SP B", Price=9_200_000 },
+                    new Product{ Name="SP C", Price=7_800_000 },
+                    new Product{ Name="SP D", Price=8_100_000 },
+                    new Product{ Name="SP E", Price=7_900_000 },
+                    new Product{ Name="SP F", Price=8_000_000 }
                 };
             }
+
             for (int i = 0; i < 6; i++) group[i] = pool[i];
 
-            // Chọn 1 index để "làm sai giá"
             fakeIndex = GameState.Rnd.Next(6);
-
-            // Tính giá hiển thị: đúng cho 5 cái, "lệch" cho 1 cái
             for (int i = 0; i < 6; i++)
             {
                 if (i == fakeIndex)
                 {
-                    // lệch ~ ±30%–60% cho lộ liễu hơn
                     var basePrice = group[i].Price;
                     var sign = GameState.Rnd.Next(2) == 0 ? -1 : 1;
-                    var pct = GameState.Rnd.Next(30, 61) / 100.0; // 30%..60%
+                    var pct = GameState.Rnd.Next(30, 61) / 100.0;
                     int altered = (int)Math.Max(1000, basePrice + sign * basePrice * pct);
                     if (altered == basePrice) altered += 10000;
                     displayPrices[i] = altered;
@@ -61,13 +70,14 @@ namespace HayChonGiaDung.Wpf
                 }
             }
 
-            // Render cards
             RenderCards();
         }
 
         private void RenderCards()
         {
             GridProducts.Children.Clear();
+            _cards.Clear();
+
             for (int i = 0; i < 6; i++)
             {
                 var sp = group[i];
@@ -76,30 +86,27 @@ namespace HayChonGiaDung.Wpf
                 var card = new Border
                 {
                     CornerRadius = new CornerRadius(16),
-                    Background = System.Windows.Media.Brushes.Transparent,
+                    Background = Brushes.Transparent,
                     BorderThickness = new Thickness(1),
-                    BorderBrush = System.Windows.Media.Brushes.DimGray,
+                    BorderBrush = Brushes.DimGray,
                     Margin = new Thickness(10),
-                    Padding = new Thickness(12)
+                    Padding = new Thickness(12),
+                    Opacity = 0
                 };
 
                 var stack = new StackPanel();
 
-                // Ảnh sản phẩm
-                var img = new Image { Height = 180, Stretch = System.Windows.Media.Stretch.UniformToFill };
-                if (!string.IsNullOrWhiteSpace(sp.ImageUrl) &&
-                    Uri.IsWellFormedUriString(sp.ImageUrl, UriKind.Absolute))
+                var img = new Image { Height = 180, Stretch = Stretch.UniformToFill };
+                if (!string.IsNullOrWhiteSpace(sp.ImageUrl) && Uri.IsWellFormedUriString(sp.ImageUrl, UriKind.Absolute))
                 {
                     img.Source = new BitmapImage(new Uri(sp.ImageUrl));
                 }
                 else if (!string.IsNullOrWhiteSpace(sp.Image))
                 {
-                    string path = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets", "Images", sp.Image);
-                    if (System.IO.File.Exists(path))
+                    string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets", "Images", sp.Image);
+                    if (File.Exists(path))
                         img.Source = new BitmapImage(new Uri(path));
                 }
-
-              
 
                 var name = new TextBlock
                 {
@@ -132,42 +139,176 @@ namespace HayChonGiaDung.Wpf
 
                 card.Child = stack;
                 GridProducts.Children.Add(card);
+                _cards.Add(card);
+
+                AnimateCard(card);
             }
+
+            SoundManager.Reveal();
         }
 
         private async void Pick(object sender, RoutedEventArgs e)
         {
-            if (picked) return; // chặn double click
+            if (picked) return;
             picked = true;
 
             int idx = (int)((Button)sender).Tag;
             bool correct = idx == fakeIndex;
 
+            HighlightSelection(idx, correct);
+
+            foreach (var button in GridProducts.Children.OfType<Border>().SelectMany(b => b.Child is StackPanel sp ? sp.Children.OfType<Button>() : Array.Empty<Button>()))
+            {
+                button.IsEnabled = false;
+            }
+
             if (correct)
             {
-                GameState.TotalPrize += 1_500_000;
+                GameState.AddPrize(1_500_000);
                 PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
                 SoundManager.Correct();
                 Feedback.Text = "✅ Chuẩn bài! +1.500.000 ₫";
+                RefreshHud();
                 await Task.Delay(1000);
-                this.DialogResult = true;
+                DialogResult = true;
                 Close();
             }
             else
             {
                 SoundManager.Wrong();
-                Feedback.Text = "❌ Sai mất rồi! Vòng này 0 ₫.";
+                Feedback.Text = $"❌ Sai mất rồi! Giá đúng của {group[fakeIndex].Name} là {group[fakeIndex].Price:N0} ₫.";
+                RefreshHud();
                 await Task.Delay(1000);
-                this.DialogResult = false;
+                DialogResult = false;
                 Close();
             }
         }
 
+        private void HintButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (hintUsed)
+            {
+                Feedback.Text = "Bạn đã dùng gợi ý.";
+                return;
+            }
+
+            if (!EnsureCardAvailable(PowerCardType.Hint, 5, "Gợi ý"))
+                return;
+
+            hintUsed = true;
+            var highlightCount = 3;
+            var highlight = new HashSet<int> { fakeIndex };
+            while (highlight.Count < highlightCount)
+            {
+                highlight.Add(GameState.Rnd.Next(group.Length));
+            }
+
+            foreach (var index in highlight)
+            {
+                _cards[index].Background = new SolidColorBrush(Color.FromArgb(40, 30, 144, 255));
+            }
+
+            Feedback.Text = "Một trong các thẻ được tô xanh là đáp án sai giá.";
+            RefreshHud();
+        }
+
+        private void SwapButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (!EnsureCardAvailable(PowerCardType.SwapProduct, 8, "Đổi bộ"))
+                return;
+
+            Feedback.Text = "Đã đổi sang bộ sản phẩm mới.";
+            RefreshHud();
+            GenerateRound();
+        }
+
+        private void DoubleButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (!EnsureCardAvailable(PowerCardType.DoubleReward, 10, "Nhân đôi"))
+                return;
+
+            GameState.QueueDoubleReward();
+            Feedback.Text = "⭐ Thẻ nhân đôi đã sẵn sàng.";
+            RefreshHud();
+        }
+
         private void Cancel_Click(object sender, RoutedEventArgs e)
         {
-            // Nếu người chơi thoát giữa chừng coi như bỏ vòng này
-            this.DialogResult = false;
+            DialogResult = false;
             Close();
+        }
+
+        private void HighlightSelection(int pickedIndex, bool correct)
+        {
+            for (int i = 0; i < _cards.Count; i++)
+            {
+                if (i == fakeIndex)
+                {
+                    _cards[i].BorderBrush = Brushes.LimeGreen;
+                    _cards[i].BorderThickness = new Thickness(3);
+                }
+                else if (i == pickedIndex && !correct)
+                {
+                    _cards[i].BorderBrush = Brushes.IndianRed;
+                    _cards[i].BorderThickness = new Thickness(3);
+                }
+                else
+                {
+                    _cards[i].BorderBrush = Brushes.DimGray;
+                    _cards[i].BorderThickness = new Thickness(1);
+                }
+            }
+        }
+
+        private void RefreshHud()
+        {
+            PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            CoinText.Text = GameState.Coins.ToString();
+            CardText.Text = $"Gợi ý {GameState.GetCardCount(PowerCardType.Hint)} • Đổi {GameState.GetCardCount(PowerCardType.SwapProduct)} • x2 {GameState.GetCardCount(PowerCardType.DoubleReward)}";
+        }
+
+        private bool EnsureCardAvailable(PowerCardType type, int coinCost, string cardLabel)
+        {
+            if (GameState.TryUsePowerCard(type))
+            {
+                return true;
+            }
+
+            if (GameState.Coins < coinCost)
+            {
+                MessageBox.Show("Bạn không còn thẻ và cũng không đủ xu để mua thêm.", cardLabel, MessageBoxButton.OK, MessageBoxImage.Information);
+                return false;
+            }
+
+            var confirm = MessageBox.Show($"Mua thẻ {cardLabel} với {coinCost} xu?", "Mua thẻ", MessageBoxButton.YesNo, MessageBoxImage.Question);
+            if (confirm != MessageBoxResult.Yes)
+            {
+                return false;
+            }
+
+            if (!GameState.TrySpendCoins(coinCost))
+            {
+                MessageBox.Show("Xu hiện có không đủ.", "Thông báo", MessageBoxButton.OK, MessageBoxImage.Information);
+                return false;
+            }
+
+            GameState.AddPowerCard(type);
+            GameState.TryUsePowerCard(type);
+            RefreshHud();
+            return true;
+        }
+
+        private void AnimateCard(Border card)
+        {
+            try
+            {
+                var animation = new DoubleAnimation(0, 1, TimeSpan.FromMilliseconds(350));
+                card.BeginAnimation(UIElement.OpacityProperty, animation);
+            }
+            catch
+            {
+                // ignore
+            }
         }
     }
 }

--- a/Round4Window.xaml
+++ b/Round4Window.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="HayChonGiaDung.Wpf.Round4Window"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Vòng 4 - Lựa Chọn Thông Minh"
+        Title="Vòng 4 - Tích Lũy Dồn Toa"
         WindowState="Maximized"
         WindowStartupLocation="CenterScreen"
         Background="{StaticResource Surface}">
@@ -15,21 +15,36 @@
         <!-- Header -->
         <DockPanel Grid.Row="0">
             <StackPanel Orientation="Vertical" DockPanel.Dock="Left">
-                <TextBlock Text="Vòng 4: Lựa Chọn Thông Minh" FontSize="30" FontWeight="Bold"/>
-                <TextBlock Text="Chọn sản phẩm có GIÁ TRUNG BÌNH (median) trong bộ 3 sản phẩm cận kề giá."
-                   Opacity="0.8" Margin="0,4,0,0"/>
+                <TextBlock Text="Vòng 4: Tích Lũy Dồn Toa" FontSize="30" FontWeight="Bold"/>
+                <TextBlock Text="Sắp xếp giá của 4-5 sản phẩm theo thứ tự tăng dần để tích lũy thưởng." Opacity="0.8" Margin="0,4,0,0"/>
             </StackPanel>
 
             <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center" >
-                <TextBlock Text="Tổng thưởng:" FontSize="18" Margin="0,0,8,0"/>
-                <TextBlock x:Name="PrizeText" FontSize="22" FontWeight="Bold"/>
+                <StackPanel Orientation="Horizontal" Margin="0,0,12,0">
+                    <TextBlock Text="💰 Xu:"/>
+                    <TextBlock x:Name="CoinText" FontWeight="Bold" Margin="4,0,0,0"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,0,12,0">
+                    <TextBlock Text="Thẻ:"/>
+                    <TextBlock x:Name="CardText" FontWeight="Bold" Margin="4,0,0,0"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="Tổng thưởng:" FontSize="18" Margin="0,0,8,0"/>
+                    <TextBlock x:Name="PrizeText" FontSize="22" FontWeight="Bold"/>
+                </StackPanel>
             </StackPanel>
         </DockPanel>
 
         <!-- Product trio -->
         <Border Grid.Row="1" Background="{StaticResource Card}" CornerRadius="18" Padding="18" Margin="0,14,0,14">
             <StackPanel>
-                <UniformGrid x:Name="GridTrio" Rows="1" Columns="3"/>
+                <StackPanel x:Name="OrderPanel" />
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,12,0,0">
+                    <Button x:Name="HintButton" Content="Gợi ý (-5 xu)" Margin="4" Click="HintButton_Click"/>
+                    <Button x:Name="SwapButton" Content="Đổi bộ (-8 xu)" Margin="4" Click="SwapButton_Click"/>
+                    <Button x:Name="DoubleButton" Content="Nhân đôi (-10 xu)" Margin="4" Click="DoubleButton_Click"/>
+                </StackPanel>
+                <Button x:Name="LockButton" Content="Khóa thứ tự" Margin="0,16,0,0" Height="48" Click="LockButton_Click"/>
                 <TextBlock x:Name="Feedback" Margin="0,16,0,0" FontSize="18" TextAlignment="Center"/>
             </StackPanel>
         </Border>

--- a/Round4Window.xaml.cs
+++ b/Round4Window.xaml.cs
@@ -1,18 +1,24 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 using System.Windows.Media.Imaging;
 
 namespace HayChonGiaDung.Wpf
 {
     public partial class Round4Window : Window
     {
-        private int correctDisplayIndex;
-        private Product[] trio = new Product[3];
-        private bool picked = false;
+        private readonly List<Product> _products = new();
+        private readonly List<int> _order = new();
+        private readonly HashSet<int> _hintHighlights = new();
+        private int? _protectedProductIndex;
+        private bool _protectPurchased;
+        private bool _hintUsed;
+        private bool _locked;
 
         public Round4Window()
         {
@@ -20,135 +26,359 @@ namespace HayChonGiaDung.Wpf
             SoundManager.StartRound();
 
             PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            RefreshHud();
+            GenerateRound();
+        }
 
-            // Lấy 3 sản phẩm CẬN KỀ GIÁ: sort theo giá rồi pick 3 món liên tiếp
-            var all = GameState.Catalog.OrderBy(p => p.Price).ToList();
-            if (all.Count >= 3)
+        private void GenerateRound()
+        {
+            _products.Clear();
+            _order.Clear();
+            _hintHighlights.Clear();
+            _protectedProductIndex = null;
+            _protectPurchased = false;
+            _hintUsed = false;
+            _locked = false;
+            Feedback.Text = string.Empty;
+            LockButton.IsEnabled = true;
+            HintButton.IsEnabled = true;
+            SwapButton.IsEnabled = true;
+            DoubleButton.IsEnabled = true;
+
+            int count = Math.Min(5, Math.Max(4, GameState.Catalog.Count >= 5 ? GameState.Rnd.Next(4, 6) : 4));
+            var selected = GameState.Catalog.OrderBy(_ => GameState.Rnd.Next()).Take(count).ToList();
+            if (selected.Count < count)
             {
-                int start = GameState.Rnd.Next(0, Math.Max(1, all.Count - 2));
-                trio[0] = all[start];
-                trio[1] = all[start + 1];
-                trio[2] = all[start + 2];
-            }
-            else
-            {
-                // fallback nếu thiếu data
-                trio = new[]
+                selected = new List<Product>
                 {
-                    new Product { Name = "SP A", Price = 1200000 },
-                    new Product { Name = "SP B", Price = 1800000 },
-                    new Product { Name = "SP C", Price = 2400000 }
+                    new Product { Name = "Quạt cây", Price = 1_200_000 },
+                    new Product { Name = "Máy xay đa năng", Price = 2_400_000 },
+                    new Product { Name = "Máy rửa chén", Price = 9_200_000 },
+                    new Product { Name = "Tủ lạnh 450L", Price = 14_500_000 }
                 };
             }
 
-            // Tính median (giữa) theo giá
-            var median = trio.OrderBy(p => p.Price).ElementAt(1);
+            _products.AddRange(selected);
+            _order.AddRange(Enumerable.Range(0, _products.Count).OrderBy(_ => GameState.Rnd.Next()));
 
-            // Xáo trộn vị trí hiển thị để tránh đoán theo vị trí
-            int[] order = new[] { 0, 1, 2 }.OrderBy(_ => GameState.Rnd.Next()).ToArray();
-            correctDisplayIndex = Array.FindIndex(order, i => trio[i] == median);
-
-            // Render 3 card
-            GridTrio.Children.Clear();
-            for (int col = 0; col < 3; col++)
+            RenderOrder();
+        }
+        private void RenderOrder()
+        {
+            OrderPanel.Children.Clear();
+            for (int position = 0; position < _order.Count; position++)
             {
-                var sp = trio[order[col]];
-                GridTrio.Children.Add(BuildCard(sp, col));
+                int productIndex = _order[position];
+                var product = _products[productIndex];
+
+                var card = new Border
+                {
+                    CornerRadius = new CornerRadius(16),
+                    BorderBrush = Brushes.DimGray,
+                    BorderThickness = new Thickness(1),
+                    Margin = new Thickness(0, 6, 0, 6),
+                    Padding = new Thickness(12),
+                    Background = _hintHighlights.Contains(productIndex)
+                        ? new SolidColorBrush(Color.FromArgb(40, 0, 191, 255))
+                        : Brushes.Transparent
+                };
+
+                var grid = new Grid { Margin = new Thickness(0, 0, 0, 6) };
+                grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(120) });
+                grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(120) });
+
+                var image = new Image
+                {
+                    Height = 80,
+                    Width = 120,
+                    Stretch = Stretch.UniformToFill,
+                    Margin = new Thickness(0, 0, 12, 0)
+                };
+                if (!string.IsNullOrWhiteSpace(product.ImageUrl) && Uri.IsWellFormedUriString(product.ImageUrl, UriKind.Absolute))
+                {
+                    image.Source = new BitmapImage(new Uri(product.ImageUrl));
+                }
+                else if (!string.IsNullOrWhiteSpace(product.Image))
+                {
+                    string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets", "Images", product.Image);
+                    if (File.Exists(path))
+                        image.Source = new BitmapImage(new Uri(path));
+                }
+                Grid.SetColumn(image, 0);
+                grid.Children.Add(image);
+
+                var infoStack = new StackPanel();
+                infoStack.Children.Add(new TextBlock
+                {
+                    Text = $"{position + 1}. {product.Name}",
+                    FontWeight = FontWeights.Bold,
+                    FontSize = 18
+                });
+                infoStack.Children.Add(new TextBlock
+                {
+                    Text = string.IsNullOrWhiteSpace(product.Description) ? "Sắp xếp từ rẻ đến đắt." : product.Description,
+                    Opacity = 0.75,
+                    TextWrapping = TextWrapping.Wrap
+                });
+                Grid.SetColumn(infoStack, 1);
+                grid.Children.Add(infoStack);
+
+                var buttonStack = new StackPanel { Orientation = Orientation.Vertical, HorizontalAlignment = HorizontalAlignment.Right };
+                var upButton = new Button { Content = "▲", Tag = productIndex, Margin = new Thickness(0, 0, 0, 4), IsEnabled = position > 0 && !_locked };
+                upButton.Click += MoveUp_Click;
+                var downButton = new Button { Content = "▼", Tag = productIndex, Margin = new Thickness(0, 0, 0, 4), IsEnabled = position < _order.Count - 1 && !_locked };
+                downButton.Click += MoveDown_Click;
+                var protectButton = new Button
+                {
+                    Content = _protectedProductIndex == productIndex ? "ĐÃ BẢO TOÀN" : "Bảo toàn (-6 xu)",
+                    Tag = productIndex,
+                    Margin = new Thickness(0, 4, 0, 0),
+                    IsEnabled = !_locked && (_protectedProductIndex == null || _protectedProductIndex == productIndex)
+                };
+                protectButton.Click += Protect_Click;
+                buttonStack.Children.Add(upButton);
+                buttonStack.Children.Add(downButton);
+                buttonStack.Children.Add(protectButton);
+                Grid.SetColumn(buttonStack, 2);
+                grid.Children.Add(buttonStack);
+
+                card.Child = grid;
+                OrderPanel.Children.Add(card);
             }
         }
-
-        private UIElement BuildCard(Product sp, int displayIndex)
+        private void MoveUp_Click(object sender, RoutedEventArgs e)
         {
-            var card = new Border
-            {
-                CornerRadius = new CornerRadius(16),
-                BorderThickness = new Thickness(1),
-                BorderBrush = System.Windows.Media.Brushes.DimGray,
-                Margin = new Thickness(10),
-                Padding = new Thickness(12)
-            };
-
-            var stack = new StackPanel();
-
-            // Ảnh sản phẩm
-            var img = new Image { Height = 180, Stretch = System.Windows.Media.Stretch.UniformToFill };
-            if (!string.IsNullOrWhiteSpace(sp.ImageUrl) &&
-                Uri.IsWellFormedUriString(sp.ImageUrl, UriKind.Absolute))
-            {
-                img.Source = new BitmapImage(new Uri(sp.ImageUrl));
-            }
-            else if (!string.IsNullOrWhiteSpace(sp.Image))
-            {
-                string path = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets", "Images", sp.Image);
-                if (System.IO.File.Exists(path))
-                    img.Source = new BitmapImage(new Uri(path));
-            }
-
-            var name = new TextBlock
-            {
-                Text = sp.Name,
-                TextWrapping = TextWrapping.Wrap,
-                FontWeight = FontWeights.Bold,
-                FontSize = 18,
-                Margin = new Thickness(0, 8, 0, 4)
-            };
-
-            var price = new TextBlock
-            {
-                Text = $"{sp.Price:N0} ₫",
-                Opacity = 0.9,
-                FontSize = 16
-            };
-
-            var btn = new Button
-            {
-                Content = "Chọn sản phẩm này",
-                Tag = displayIndex,
-                Margin = new Thickness(0, 10, 0, 0)
-            };
-            btn.Click += Pick;
-
-            stack.Children.Add(img);
-            stack.Children.Add(name);
-            stack.Children.Add(price);
-            stack.Children.Add(btn);
-
-            card.Child = stack;
-            return card;
+            if (_locked) return;
+            int productIndex = (int)((Button)sender).Tag;
+            int currentPos = _order.IndexOf(productIndex);
+            if (currentPos <= 0) return;
+            (_order[currentPos - 1], _order[currentPos]) = (_order[currentPos], _order[currentPos - 1]);
+            RenderOrder();
         }
 
-        private async void Pick(object sender, RoutedEventArgs e)
+        private void MoveDown_Click(object sender, RoutedEventArgs e)
         {
-            if (picked) return;
-            picked = true;
+            if (_locked) return;
+            int productIndex = (int)((Button)sender).Tag;
+            int currentPos = _order.IndexOf(productIndex);
+            if (currentPos >= _order.Count - 1) return;
+            (_order[currentPos + 1], _order[currentPos]) = (_order[currentPos], _order[currentPos + 1]);
+            RenderOrder();
+        }
 
-            int idx = (int)((Button)sender).Tag;
-            if (idx == correctDisplayIndex)
+        private void Protect_Click(object sender, RoutedEventArgs e)
+        {
+            if (_locked) return;
+            int productIndex = (int)((Button)sender).Tag;
+
+            if (_protectedProductIndex == productIndex)
             {
-                GameState.TotalPrize += 2_000_000;
+                _protectedProductIndex = null;
+                Feedback.Text = "Đã bỏ bảo toàn cho sản phẩm.";
+                RenderOrder();
+                RefreshHud();
+                return;
+            }
+
+            if (!_protectPurchased)
+            {
+                if (GameState.Coins < 6)
+                {
+                    MessageBox.Show("Bạn không đủ xu để bảo toàn sản phẩm.", "Bảo toàn", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
+                var confirm = MessageBox.Show("Bảo toàn sản phẩm này với 6 xu?", "Bảo toàn", MessageBoxButton.YesNo, MessageBoxImage.Question);
+                if (confirm != MessageBoxResult.Yes)
+                {
+                    return;
+                }
+
+                if (!GameState.TrySpendCoins(6))
+                {
+                    MessageBox.Show("Không thể trừ xu lúc này.", "Bảo toàn", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
+                _protectPurchased = true;
+            }
+
+            _protectedProductIndex = productIndex;
+            Feedback.Text = $"Đã bảo toàn { _products[productIndex].Name }. Nếu sai vị trí vẫn giữ 500.000 ₫.";
+            RenderOrder();
+            RefreshHud();
+        }
+        private void HintButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_hintUsed)
+            {
+                Feedback.Text = "Bạn đã dùng gợi ý.";
+                return;
+            }
+
+            if (!EnsureCardAvailable(PowerCardType.Hint, 5, "Gợi ý"))
+                return;
+
+            _hintUsed = true;
+            var sorted = _products.Select((p, i) => new { Index = i, p.Price }).OrderBy(p => p.Price).ToList();
+            var chosen = sorted[GameState.Rnd.Next(sorted.Count)];
+            int targetPos = sorted.IndexOf(chosen);
+            _hintHighlights.Add(chosen.Index);
+            Feedback.Text = $"Gợi ý: { _products[chosen.Index].Name } nên đứng ở vị trí số {targetPos + 1}.";
+            RenderOrder();
+            RefreshHud();
+        }
+
+        private void SwapButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (!EnsureCardAvailable(PowerCardType.SwapProduct, 8, "Đổi bộ"))
+                return;
+
+            Feedback.Text = "Đã đổi sang bộ sản phẩm mới.";
+            RefreshHud();
+            GenerateRound();
+        }
+
+        private void DoubleButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (!EnsureCardAvailable(PowerCardType.DoubleReward, 10, "Nhân đôi"))
+                return;
+
+            GameState.QueueDoubleReward();
+            Feedback.Text = "⭐ Thẻ nhân đôi đã kích hoạt.";
+            RefreshHud();
+        }
+
+        private async void LockButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_locked) return;
+            _locked = true;
+
+            LockButton.IsEnabled = false;
+            HintButton.IsEnabled = false;
+            SwapButton.IsEnabled = false;
+            DoubleButton.IsEnabled = false;
+            RenderOrder();
+
+            var sorted = _products.Select((p, i) => new { Index = i, p.Price })
+                                   .OrderBy(p => p.Price)
+                                   .Select(p => p.Index)
+                                   .ToList();
+
+            int correct = 0;
+            int totalReward = 0;
+            for (int pos = 0; pos < _order.Count; pos++)
+            {
+                int productIndex = _order[pos];
+                if (sorted[pos] == productIndex)
+                {
+                    correct++;
+                    totalReward += 1_500_000;
+                }
+                else if (_protectedProductIndex.HasValue && _protectedProductIndex.Value == productIndex)
+                {
+                    totalReward += 500_000;
+                }
+            }
+
+            if (totalReward > 0)
+            {
+                GameState.AddPrize(totalReward);
                 PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            }
+
+            var sortedNames = string.Join(" < ", sorted.Select(i => _products[i].Name));
+            Feedback.Text = $"Bạn đặt đúng {correct}/{_order.Count} vị trí. Thưởng: {totalReward:N0} ₫. Thứ tự chuẩn: {sortedNames}.";
+
+            if (correct == _order.Count)
+            {
                 SoundManager.Correct();
-                Feedback.Text = "✅ Quá thông minh! +2.000.000 ₫";
-                await Task.Delay(1000);
-                LeaderboardService.AddScore(GameState.PlayerName, GameState.TotalPrize);
-                this.DialogResult = true;
-                Close();
+            }
+            else if (totalReward > 0)
+            {
+                SoundManager.Correct();
             }
             else
             {
                 SoundManager.Wrong();
-                Feedback.Text = "❌ Sai nước đi! Vòng này 0 ₫.";
-                await Task.Delay(1000);
-                LeaderboardService.AddScore(GameState.PlayerName, GameState.TotalPrize);
-                this.DialogResult = false;
-                Close();
+            }
+
+            HighlightResults(sorted);
+            RefreshHud();
+            LeaderboardService.AddScore(GameState.PlayerName, GameState.TotalPrize);
+            await Task.Delay(1200);
+            DialogResult = true;
+            Close();
+        }
+        private void HighlightResults(IReadOnlyList<int> sorted)
+        {
+            for (int pos = 0; pos < _order.Count; pos++)
+            {
+                if (OrderPanel.Children[pos] is Border border)
+                {
+                    int productIndex = _order[pos];
+                    if (sorted[pos] == productIndex)
+                    {
+                        border.BorderBrush = Brushes.LimeGreen;
+                        border.BorderThickness = new Thickness(3);
+                    }
+                    else if (_protectedProductIndex.HasValue && _protectedProductIndex.Value == productIndex)
+                    {
+                        border.BorderBrush = Brushes.Goldenrod;
+                        border.BorderThickness = new Thickness(3);
+                    }
+                    else
+                    {
+                        border.BorderBrush = Brushes.IndianRed;
+                        border.BorderThickness = new Thickness(3);
+                    }
+                }
             }
         }
 
         private void Cancel_Click(object sender, RoutedEventArgs e)
         {
-            this.DialogResult = false;
+            LeaderboardService.AddScore(GameState.PlayerName, GameState.TotalPrize);
+            DialogResult = false;
             Close();
+        }
+
+        private void RefreshHud()
+        {
+            CoinText.Text = GameState.Coins.ToString();
+            CardText.Text = $"Gợi ý {GameState.GetCardCount(PowerCardType.Hint)} • Đổi {GameState.GetCardCount(PowerCardType.SwapProduct)} • x2 {GameState.GetCardCount(PowerCardType.DoubleReward)}";
+        }
+
+        private bool EnsureCardAvailable(PowerCardType type, int coinCost, string cardLabel)
+        {
+            if (GameState.TryUsePowerCard(type))
+            {
+                return true;
+            }
+
+            if (GameState.Coins < coinCost)
+            {
+                MessageBox.Show("Bạn không còn thẻ và cũng không đủ xu để mua thêm.", cardLabel, MessageBoxButton.OK, MessageBoxImage.Information);
+                return false;
+            }
+
+            var confirm = MessageBox.Show($"Mua thẻ {cardLabel} với {coinCost} xu?", "Mua thẻ", MessageBoxButton.YesNo, MessageBoxImage.Question);
+            if (confirm != MessageBoxResult.Yes)
+            {
+                return false;
+            }
+
+            if (!GameState.TrySpendCoins(coinCost))
+            {
+                MessageBox.Show("Xu hiện có không đủ.", "Thông báo", MessageBoxButton.OK, MessageBoxImage.Information);
+                return false;
+            }
+
+            GameState.AddPowerCard(type);
+            GameState.TryUsePowerCard(type);
+            RefreshHud();
+            return true;
         }
     }
 }

--- a/SoundManager.cs
+++ b/SoundManager.cs
@@ -86,6 +86,7 @@ namespace HayChonGiaDung.Wpf
         public static void StartRound() => PlayOneShot("Choi.wav");
         public static void Win() => PlayOneShot("Win.wav");
         public static void End() => PlayOneShot("End.wav");
+        public static void Reveal() => PlayOneShot("Topic.wav");
         public static void PlayPreview(double volume) =>
             PlayOneShot("Correct.wav", Math.Clamp(volume, 0.0, 1.0), bypassMute: true);
 


### PR DESCRIPTION
## Summary
- introduce a QuickStart warmup window with trivia, coin rewards, and a power-card shop
- extend GameState tracking with coins and reusable power cards, updating the lobby HUD and card usage flows across rounds
- redesign rounds: Round1 uses ±10% price guesses with hints/swap/double, Round2 alternates highest/lowest picks, Round3 gains reusable support actions, and Round4 becomes an ordering challenge with protection logic
- add reveal audio support and ensure prize additions respect queued double rewards and updated coin displays

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b4efd52c833382dd79d5b0d5ccab