### PR TITLE
Add quick start, help cards, and finale round

### DIFF
--- a/GameState.cs
+++ b/GameState.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace HayChonGiaDung.Wpf
 {
@@ -10,15 +11,69 @@ namespace HayChonGiaDung.Wpf
         public static Random Rnd { get; } = new Random();
         public static List<Product> Catalog { get; private set; } = ProductRepository.LoadProducts();
 
+        public static int QuickCoins { get; private set; }
+            = 0; // xu thưởng từ vòng khởi động
+
+        private static readonly Dictionary<HelpCardType, int> _helpCards = new()
+        {
+            { HelpCardType.Hint, 0 },
+            { HelpCardType.SwapProduct, 0 },
+            { HelpCardType.DoubleReward, 0 }
+        };
+
+        public static int GetHelpCount(HelpCardType type) => _helpCards[type];
+
+        public static void AddHelpCard(HelpCardType type, int amount = 1)
+        {
+            if (amount <= 0) return;
+            _helpCards[type] = Math.Max(0, _helpCards[type] + amount);
+        }
+
+        public static bool UseHelpCard(HelpCardType type)
+        {
+            if (_helpCards[type] <= 0) return false;
+            _helpCards[type]--;
+            return true;
+        }
+
+        public static void AddCoins(int amount)
+        {
+            if (amount <= 0) return;
+            QuickCoins += amount;
+        }
+
+        public static bool SpendCoins(int amount)
+        {
+            if (amount <= 0) return true;
+            if (QuickCoins < amount) return false;
+            QuickCoins -= amount;
+            return true;
+        }
+
         public static void Reset()
         {
             TotalPrize = 0;
+            QuickCoins = 0;
+            foreach (var key in _helpCards.Keys.ToList())
+            {
+                _helpCards[key] = 0;
+            }
         }
 
         public static void ReloadCatalog()
         {
             Catalog = ProductRepository.LoadProducts();
         }
+
+        public static IReadOnlyDictionary<HelpCardType, int> GetInventory()
+            => _helpCards;
+    }
+
+    public enum HelpCardType
+    {
+        Hint,
+        SwapProduct,
+        DoubleReward
     }
 
     public class Product

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -3,13 +3,13 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Hãy Chọn Giá Đúng" Height="720" Width="1100" Background="{StaticResource Surface}">
     
-    <Grid Margin="24">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <TextBlock Text="Hãy Chọn Giá Đúng" FontSize="30" FontWeight="Bold"/>
+  <Grid Margin="24">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="*"/>
+      <RowDefinition Height="Auto"/>
+    </Grid.RowDefinitions>
+    <TextBlock Text="Hãy Chọn Giá Đúng" FontSize="30" FontWeight="Bold"/>
     <Border Grid.Row="1" Background="{StaticResource Card}" CornerRadius="16" Padding="20" Margin="0,16,0,16">
       <StackPanel>
         <TextBlock Text="Nhập tên người chơi:" Margin="0,0,0,8"/>
@@ -19,9 +19,26 @@
       </StackPanel>
     </Border>
 
-    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" >
-      <TextBlock Text="Tổng tiền thưởng:"/>
-      <TextBlock x:Name="PrizeText" FontWeight="Bold"/>
-    </StackPanel>
+    <DockPanel Grid.Row="2" LastChildFill="False">
+      <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" Spacing="8">
+        <Border Background="#233457" CornerRadius="12" Padding="12,6">
+          <StackPanel Orientation="Horizontal" Spacing="6">
+            <TextBlock Text="💰" FontSize="20"/>
+            <TextBlock Text="Xu:"/>
+            <TextBlock x:Name="CoinText" FontWeight="Bold"/>
+          </StackPanel>
+        </Border>
+        <Border Background="#233457" CornerRadius="12" Padding="12,6">
+          <StackPanel Orientation="Horizontal" Spacing="6">
+            <TextBlock Text="Thẻ:"/>
+            <TextBlock x:Name="CardText" FontWeight="Bold"/>
+          </StackPanel>
+        </Border>
+      </StackPanel>
+      <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" HorizontalAlignment="Right" Spacing="6">
+        <TextBlock Text="Tổng tiền thưởng:"/>
+        <TextBlock x:Name="PrizeText" FontWeight="Bold"/>
+      </StackPanel>
+    </DockPanel>
   </Grid>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Windows;
 
 namespace HayChonGiaDung.Wpf
@@ -19,32 +20,71 @@ namespace HayChonGiaDung.Wpf
                 StatusText.Text = "Vui lòng nhập tên!";
                 return;
             }
-            GameState.PlayerName = PlayerNameBox.Text.Trim();
             GameState.Reset();
+            GameState.PlayerName = PlayerNameBox.Text.Trim();
             PrizeText.Text = "0 ₫";
+            RefreshHud();
+
+            var quick = new QuickStartWindow { Owner = this };
+            quick.ShowDialog();
+            RefreshHud();
+            if (quick.DialogResult != true)
+            {
+                ReturnToStart();
+                return;
+            }
 
             var r1 = new Round1Window();
             r1.Owner = this;
             r1.ShowDialog();
             PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            RefreshHud();
             if (HandleGameOver()) { return; }
 
             var r2 = new Round2Window(); r2.Owner = this; r2.ShowDialog();
             PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            RefreshHud();
             if (HandleGameOver()) { return; }
 
             var r3 = new Round3Window(); r3.Owner = this; r3.ShowDialog();
             PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            RefreshHud();
             if (HandleGameOver()) { return; }
 
             var r4 = new Round4Window(); r4.Owner = this; r4.ShowDialog();
             PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            RefreshHud();
+            if (HandleGameOver()) { return; }
+
+            var r5 = new Round5Window(); r5.Owner = this; r5.ShowDialog();
+            PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            RefreshHud();
             if (HandleGameOver()) { return; }
 
             SoundManager.Win();
             MessageBox.Show($"Chúc mừng {GameState.PlayerName}! Bạn đã hoàn thành tất cả vòng chơi.\nTổng thưởng: {GameState.TotalPrize:N0} ₫","Hoàn thành");
             ReturnToStart();
         }
+
+        private void RefreshHud()
+        {
+            CoinText.Text = GameState.QuickCoins.ToString();
+            CardText.Text = string.Join(", ", GameState.GetInventory()
+                .Where(kv => kv.Value > 0)
+                .Select(kv => $"{GetCardName(kv.Key)} x{kv.Value}"));
+            if (string.IsNullOrWhiteSpace(CardText.Text))
+            {
+                CardText.Text = "Chưa có";
+            }
+        }
+
+        private static string GetCardName(HelpCardType type) => type switch
+        {
+            HelpCardType.Hint => "Gợi ý",
+            HelpCardType.SwapProduct => "Đổi sản phẩm",
+            HelpCardType.DoubleReward => "Nhân đôi",
+            _ => type.ToString()
+        };
 
         private bool HandleGameOver()
         {

--- a/QuickStartWindow.xaml
+++ b/QuickStartWindow.xaml
@@ -1,0 +1,87 @@
+<Window x:Class="HayChonGiaDung.Wpf.QuickStartWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Vòng Khởi Động" WindowState="Maximized"
+        Background="{StaticResource Surface}">
+    <Grid Margin="24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <DockPanel Grid.Row="0">
+            <StackPanel Orientation="Vertical" DockPanel.Dock="Left">
+                <TextBlock Text="Khởi động nhanh" FontSize="32" FontWeight="Bold"/>
+                <TextBlock x:Name="ProgressText" Margin="0,4,0,0" Opacity="0.8"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center" Spacing="12">
+                <Border Background="#243357" CornerRadius="12" Padding="12,6">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <TextBlock Text="💰" FontSize="20"/>
+                        <TextBlock Text="Xu:"/>
+                        <TextBlock x:Name="CoinText" FontWeight="Bold"/>
+                    </StackPanel>
+                </Border>
+                <Border Background="#243357" CornerRadius="12" Padding="12,6">
+                    <StackPanel>
+                        <TextBlock Text="Thẻ trợ giúp" FontWeight="Bold"/>
+                        <TextBlock x:Name="CardText" FontSize="14" TextWrapping="Wrap" MaxWidth="260"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </DockPanel>
+
+        <Border Grid.Row="1" Background="{StaticResource Card}" CornerRadius="18" Padding="26" Margin="0,16,0,0">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <StackPanel x:Name="QuestionPanel" Grid.Row="0" VerticalAlignment="Center" Spacing="16">
+                    <TextBlock x:Name="QuestionText" FontSize="24" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                    <ItemsControl x:Name="AnswerList">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Margin="0,6" CornerRadius="12" BorderThickness="1" BorderBrush="#394867">
+                                    <RadioButton GroupName="Answers" Content="{Binding Text}" FontSize="20" Padding="12" Tag="{Binding Index}" Checked="Answer_Checked"/>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <TextBlock x:Name="QuestionHint" Opacity="0.8" TextWrapping="Wrap"/>
+                </StackPanel>
+
+                <StackPanel x:Name="StorePanel" Grid.Row="0" Visibility="Collapsed" Spacing="18">
+                    <TextBlock Text="Đổi xu lấy thẻ trợ giúp trước khi vào vòng chính" FontSize="24" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                    <ItemsControl x:Name="StoreList">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Margin="0,6" CornerRadius="12" Background="#1c2847" Padding="14">
+                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" VerticalAlignment="Center" Spacing="12">
+                                        <StackPanel Width="400">
+                                            <TextBlock Text="{Binding Name}" FontWeight="Bold" FontSize="20"/>
+                                            <TextBlock Text="{Binding Description}" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                        <StackPanel>
+                                            <TextBlock Text="Giá" FontSize="14" Opacity="0.8"/>
+                                            <TextBlock Text="{Binding CostText}" FontWeight="Bold" FontSize="18"/>
+                                        </StackPanel>
+                                        <Button Content="Mua" Tag="{Binding Type}" Width="120" Click="BuyCard_Click"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="12">
+                    <Button x:Name="ActionButton" Content="Trả lời" Width="160" Height="50" FontSize="18" Click="ActionButton_Click"/>
+                    <Button x:Name="SkipButton" Content="Bỏ qua" Width="120" Height="50" FontSize="18" Click="SkipButton_Click" Visibility="Collapsed"/>
+                </StackPanel>
+
+                <TextBlock x:Name="Feedback" Grid.Row="1" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="18"/>
+            </Grid>
+        </Border>
+    </Grid>
+</Window>

--- a/QuickStartWindow.xaml.cs
+++ b/QuickStartWindow.xaml.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace HayChonGiaDung.Wpf
+{
+    public partial class QuickStartWindow : Window
+    {
+        private readonly List<QuickQuestion> _questions;
+        private int _currentIndex = -1;
+        private int? _selectedIndex = null;
+        private readonly List<HelpStoreItem> _storeItems;
+        private bool _inStorePhase = false;
+
+        public QuickStartWindow()
+        {
+            InitializeComponent();
+            WindowState = WindowState.Maximized;
+            SoundManager.StartRound();
+
+            _questions = BuildQuestions().OrderBy(_ => GameState.Rnd.Next()).Take(6).ToList();
+            _storeItems = BuildStore();
+
+            StoreList.ItemsSource = _storeItems;
+
+            NextQuestion();
+            UpdateInventoryPanel();
+        }
+
+        private void NextQuestion()
+        {
+            _currentIndex++;
+            _selectedIndex = null;
+            Feedback.Text = string.Empty;
+            QuestionHint.Text = string.Empty;
+
+            if (_currentIndex >= _questions.Count)
+            {
+                EnterStorePhase();
+                return;
+            }
+
+            var q = _questions[_currentIndex];
+            ProgressText.Text = $"Câu hỏi {_currentIndex + 1}/{_questions.Count}";
+            QuestionText.Text = q.Text;
+            AnswerList.ItemsSource = q.Options
+                .Select((text, idx) => new { Text = $"{(char)('A' + idx)}. {text}", Index = idx })
+                .ToList();
+            QuestionPanel.Visibility = Visibility.Visible;
+            StorePanel.Visibility = Visibility.Collapsed;
+            ActionButton.Content = "Trả lời";
+            SkipButton.Visibility = Visibility.Visible;
+        }
+
+        private void EnterStorePhase()
+        {
+            _inStorePhase = true;
+            ProgressText.Text = "Hoàn thành khởi động";
+            QuestionPanel.Visibility = Visibility.Collapsed;
+            StorePanel.Visibility = Visibility.Visible;
+            ActionButton.Content = "Bắt đầu vòng 1";
+            SkipButton.Visibility = Visibility.Collapsed;
+            Feedback.Text = "Bạn có thể dùng xu để mua thẻ hỗ trợ.";
+            UpdateInventoryPanel();
+        }
+
+        private static List<QuickQuestion> BuildQuestions() => new()
+        {
+            new QuickQuestion("Nồi chiên không dầu hoạt động dựa trên nguyên lý chính nào?",
+                new[]
+                {
+                    "Dùng áp suất cao",
+                    "Lưu thông khí nóng đối lưu",
+                    "Chiên bằng hồng ngoại",
+                    "Đun sôi dầu truyền thống"
+                }, 1,
+                "Máy dùng quạt thổi khí nóng tuần hoàn để làm chín thực phẩm."),
+            new QuickQuestion("Chuẩn năng lượng 5 sao trên nhãn năng lượng Việt Nam thể hiện điều gì?",
+                new[]
+                {
+                    "Sản phẩm xuất xứ châu Âu",
+                    "Sản phẩm tiết kiệm điện nhất trong nhóm",
+                    "Sản phẩm bảo hành 5 năm",
+                    "Sản phẩm chống nước chuẩn IPX5"
+                }, 1,
+                "Nhãn càng nhiều sao càng tiết kiệm điện."),
+            new QuickQuestion("Bột giặt và nước giặt khác nhau ở điểm nổi bật nào?",
+                new[]
+                {
+                    "Bột giặt chỉ dùng cho máy cửa trên",
+                    "Nước giặt dễ hòa tan, ít để lại cặn",
+                    "Bột giặt thơm hơn nước giặt",
+                    "Nước giặt không dùng được cho máy giặt"
+                }, 1,
+                "Nước giặt tan nhanh nên phù hợp giặt lạnh, ít để lại cặn."),
+            new QuickQuestion("Khi sử dụng tủ lạnh mới mua về, nên làm gì trước khi cắm điện?",
+                new[]
+                {
+                    "Cắm điện và cho thực phẩm ngay",
+                    "Để yên tối thiểu 4-6 tiếng cho gas ổn định",
+                    "Vệ sinh bằng nước nóng",
+                    "Lật ngược tủ lạnh 1 phút"
+                }, 1,
+                "Để gas hồi vị trí ban đầu sau quá trình vận chuyển."),
+            new QuickQuestion("Tiêu chí quan trọng khi chọn máy lọc không khí cho phòng ngủ là gì?",
+                new[]
+                {
+                    "Công suất bơm nước",
+                    "Độ ồn thấp, có chế độ ban đêm",
+                    "Có nhiều đèn LED nhiều màu",
+                    "Trọng lượng càng nặng càng tốt"
+                }, 1,
+                "Phòng ngủ cần yên tĩnh để không ảnh hưởng giấc ngủ."),
+            new QuickQuestion("Chức năng Inverter trên điều hòa giúp ích điều gì?",
+                new[]
+                {
+                    "Thổi gió xa hơn",
+                    "Tiết kiệm điện, vận hành ổn định",
+                    "Tự phát Wifi",
+                    "Tăng nhiệt độ tối đa"
+                }, 1,
+                "Biến tần giúp máy hoạt động êm và tiết kiệm điện."),
+            new QuickQuestion("Khi mua nồi cơm điện, thông số nào quyết định nấu được bao nhiêu gạo?",
+                new[]
+                {
+                    "Điện áp",
+                    "Dung tích nồi (lít)",
+                    "Công suất",
+                    "Số lớp chống dính"
+                }, 1,
+                "Dung tích càng lớn thì nấu được nhiều gạo."),
+            new QuickQuestion("Chuẩn IP của máy rửa xe gia đình thể hiện điều gì?",
+                new[]
+                {
+                    "Tốc độ vòng quay động cơ",
+                    "Khả năng chống bụi nước của thiết bị",
+                    "Nguồn gốc xuất xứ",
+                    "Mức độ tiết kiệm điện"
+                }, 1,
+                "IP cao bảo vệ tốt khỏi bụi và nước."),
+        };
+
+        private static List<HelpStoreItem> BuildStore() => new()
+        {
+            new HelpStoreItem(HelpCardType.Hint, "Xem gợi ý", 2,
+                "Nhận gợi ý sâu hơn về đáp án hoặc giới hạn giá."),
+            new HelpStoreItem(HelpCardType.SwapProduct, "Đổi sản phẩm", 3,
+                "Đổi sang một sản phẩm khác nếu câu hỏi quá khó."),
+            new HelpStoreItem(HelpCardType.DoubleReward, "Nhân đôi phần thưởng", 4,
+                "Dùng trước khi trả lời để nhân đôi tiền thưởng vòng đó."),
+        };
+
+        private void Answer_Checked(object sender, RoutedEventArgs e)
+        {
+            if (sender is not RadioButton rb) return;
+            _selectedIndex = (int)rb.Tag;
+        }
+
+        private void ActionButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_inStorePhase)
+            {
+                DialogResult = true;
+                Close();
+                return;
+            }
+
+            if (_selectedIndex == null)
+            {
+                Feedback.Text = "Hãy chọn một đáp án.";
+                return;
+            }
+
+            var question = _questions[_currentIndex];
+            if (_selectedIndex.Value == question.CorrectIndex)
+            {
+                GameState.AddCoins(2);
+                Feedback.Text = "✅ Chính xác! +2 xu";
+                QuestionHint.Text = question.Explanation;
+                SoundManager.Correct();
+            }
+            else
+            {
+                Feedback.Text = $"❌ Sai rồi! Đáp án đúng là {(char)('A' + question.CorrectIndex)}.";
+                QuestionHint.Text = question.Explanation;
+                SoundManager.Wrong();
+            }
+
+            UpdateInventoryPanel();
+            ActionButton.Content = "Câu tiếp";
+            SkipButton.Visibility = Visibility.Collapsed;
+            ActionButton.Click -= ActionButton_Click;
+            ActionButton.Click += NextQuestion_Click;
+        }
+
+        private void NextQuestion_Click(object sender, RoutedEventArgs e)
+        {
+            ActionButton.Click -= NextQuestion_Click;
+            ActionButton.Click += ActionButton_Click;
+            NextQuestion();
+        }
+
+        private void SkipButton_Click(object sender, RoutedEventArgs e)
+        {
+            _selectedIndex = null;
+            Feedback.Text = "Bạn đã bỏ qua câu này.";
+            SoundManager.Wrong();
+            ActionButton.Content = "Câu tiếp";
+            SkipButton.Visibility = Visibility.Collapsed;
+            ActionButton.Click -= ActionButton_Click;
+            ActionButton.Click += NextQuestion_Click;
+        }
+
+        private void BuyCard_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button btn || btn.Tag is not HelpCardType type) return;
+            var item = _storeItems.First(s => s.Type == type);
+            if (!GameState.SpendCoins(item.Cost))
+            {
+                Feedback.Text = "Không đủ xu để mua thẻ này.";
+                return;
+            }
+
+            GameState.AddHelpCard(type);
+            Feedback.Text = $"Đã mua thẻ {item.Name}.";
+            SoundManager.Correct();
+            UpdateInventoryPanel();
+        }
+
+        private void UpdateInventoryPanel()
+        {
+            CoinText.Text = GameState.QuickCoins.ToString();
+            CardText.Text = string.Join(" \u2022 ", GameState.GetInventory()
+                .Where(kv => kv.Value > 0)
+                .Select(kv => $"{GetCardName(kv.Key)} x{kv.Value}"));
+            if (string.IsNullOrWhiteSpace(CardText.Text))
+            {
+                CardText.Text = "Chưa có thẻ";
+            }
+        }
+
+        private static string GetCardName(HelpCardType type) => type switch
+        {
+            HelpCardType.Hint => "Gợi ý",
+            HelpCardType.SwapProduct => "Đổi sản phẩm",
+            HelpCardType.DoubleReward => "Nhân đôi",
+            _ => type.ToString()
+        };
+    }
+
+    public record QuickQuestion(string Text, IReadOnlyList<string> Options, int CorrectIndex, string Explanation);
+
+    public record HelpStoreItem(HelpCardType Type, string Name, int Cost, string Description)
+    {
+        public string CostText => $"{Cost} xu";
+    }
+}

--- a/Round1Window.xaml
+++ b/Round1Window.xaml
@@ -47,15 +47,29 @@
 
                 <!-- RIGHT: question & actions -->
                 <StackPanel Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center" Width="520">
-                    <TextBlock Text="GIÁ ẨN" FontSize="18" Opacity="0.8" HorizontalAlignment="Center"/>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8">
+                        <TextBlock Text="GIÁ ẨN" FontSize="18" Opacity="0.8"/>
+                        <TextBlock x:Name="ModeText" FontSize="16" Opacity="0.8"/>
+                    </StackPanel>
                     <TextBlock x:Name="Question" FontSize="20" FontWeight="Bold" TextAlignment="Center" Margin="0,4,0,16"/>
 
-                    <UniformGrid Columns="2" Rows="1" Margin="0,6,0,6">
+                    <UniformGrid x:Name="HigherLowerPanel" Columns="2" Rows="1" Margin="0,6,0,6">
                         <Button x:Name="HigherButton" Content="CAO HƠN" Height="70" FontSize="22" Click="Higher_Click" Margin="6"/>
                         <Button x:Name="LowerButton" Content="THẤP HƠN" Height="70" FontSize="22" Click="Lower_Click"  Margin="6"/>
                     </UniformGrid>
 
-                    <TextBlock x:Name="Feedback" FontSize="18" TextAlignment="Center" Margin="0,10,0,0"/>
+                    <StackPanel x:Name="RangePanel" Visibility="Collapsed" Margin="0,6,0,6" Spacing="10">
+                        <TextBlock Text="Nhập giá bạn đoán (₫)" FontSize="16" HorizontalAlignment="Center"/>
+                        <TextBox x:Name="RangeInput" FontSize="22" Padding="10" HorizontalContentAlignment="Center"/>
+                        <Button Content="Xác nhận" Height="60" FontSize="20" Click="RangeSubmit_Click"/>
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0" Spacing="12">
+                        <Button x:Name="HintButton" Content="Xem gợi ý" Click="Hint_Click"/>
+                        <Button x:Name="SwapButton" Content="Đổi sản phẩm" Click="Swap_Click"/>
+                    </StackPanel>
+
+                    <TextBlock x:Name="Feedback" FontSize="18" TextAlignment="Center" Margin="0,12,0,0" TextWrapping="Wrap"/>
                 </StackPanel>
             </Grid>
         </Border>

--- a/Round1Window.xaml.cs
+++ b/Round1Window.xaml.cs
@@ -15,6 +15,8 @@ namespace HayChonGiaDung.Wpf
         private int qty = 1;
         private int hiddenPrice = 0;
         private int correctPrice = 0;
+        private bool rangeMode = true;
+        private bool hintUsedThisQuestion = false;
 
         public Round1Window()
         {
@@ -42,9 +44,15 @@ namespace HayChonGiaDung.Wpf
             var delta = (int)(correctPrice * 0.2);
             hiddenPrice = Math.Max(1000, correctPrice + GameState.Rnd.Next(-delta, delta + 1));
 
+            rangeMode = questionIndex <= 5;
+            hintUsedThisQuestion = false;
+
             // UI text
             ProductName.Text = $"{current.Name} x{qty}";
-            Question.Text = $"{hiddenPrice:N0} ₫ — Giá đúng CAO HƠN hay THẤP HƠN?";
+            ModeText.Text = rangeMode ? "±10%" : "Cao/Thấp";
+            Question.Text = rangeMode
+                ? $"Bạn đoán giá bao nhiêu? Sai số cho phép ±10% so với giá thật."
+                : $"{hiddenPrice:N0} ₫ — Giá đúng CAO HƠN hay THẤP HƠN?";
 
             // description (nếu có), fallback câu mặc định
             ProductDesc.Text = GetDescriptionOrDefault(current);
@@ -68,9 +76,13 @@ namespace HayChonGiaDung.Wpf
                 ? "Chưa có mô tả cho sản phẩm này."
                 : current.Description;
 
-
             Feedback.Text = "";
             CorrectCount.Text = $"{correct}/4";
+
+            HigherLowerPanel.Visibility = rangeMode ? Visibility.Collapsed : Visibility.Visible;
+            RangePanel.Visibility = rangeMode ? Visibility.Visible : Visibility.Collapsed;
+            RangeInput.Text = string.Empty;
+            UpdateHelpButtons();
         }
 
         // Lấy mô tả nếu Product có property "Description" (nullable) hoặc trả về fallback
@@ -116,6 +128,89 @@ namespace HayChonGiaDung.Wpf
 
         private async void Higher_Click(object sender, RoutedEventArgs e) => await EvaluateAsync(true);
         private async void Lower_Click(object sender, RoutedEventArgs e) => await EvaluateAsync(false);
+
+        private async void RangeSubmit_Click(object sender, RoutedEventArgs e)
+        {
+            if (!int.TryParse(RangeInput.Text.Replace(".", "").Replace(",", "").Trim(), out var guess) || guess <= 0)
+            {
+                Feedback.Text = "⚠️ Nhập giá hợp lệ (số nguyên).";
+                return;
+            }
+
+            var button = (System.Windows.Controls.Button)sender;
+            RangeInput.IsEnabled = false;
+            button.IsEnabled = false;
+
+            var tolerance = (int)(correctPrice * 0.1);
+            if (Math.Abs(guess - correctPrice) <= tolerance)
+            {
+                correct++;
+                Feedback.Text = $"✅ Chuẩn! Giá đúng: {correctPrice:N0} ₫";
+                SoundManager.Correct();
+            }
+            else
+            {
+                Feedback.Text = $"❌ Lệch rồi! Giá đúng: {correctPrice:N0} ₫";
+                SoundManager.Wrong();
+            }
+            CorrectCount.Text = $"{correct}/4";
+
+            await Task.Delay(1000);
+
+            RangeInput.IsEnabled = true;
+            button.IsEnabled = true;
+
+            NextQuestion();
+        }
+
+        private void Hint_Click(object sender, RoutedEventArgs e)
+        {
+            if (hintUsedThisQuestion)
+            {
+                Feedback.Text = "Bạn đã dùng gợi ý cho câu này.";
+                return;
+            }
+
+            if (!GameState.UseHelpCard(HelpCardType.Hint))
+            {
+                Feedback.Text = "Bạn không còn thẻ gợi ý.";
+                return;
+            }
+
+            hintUsedThisQuestion = true;
+
+            if (rangeMode)
+            {
+                int tolerance = (int)(correctPrice * 0.08);
+                Feedback.Text = $"🔍 Gợi ý: Giá nằm trong khoảng {correctPrice - tolerance:N0} ₫ - {correctPrice + tolerance:N0} ₫";
+            }
+            else
+            {
+                string relation = correctPrice > hiddenPrice ? "cao hơn" : "thấp hơn";
+                Feedback.Text = $"🔍 Gợi ý: Giá thật {relation} số hiển thị từ {Math.Abs(correctPrice - hiddenPrice):N0} ₫";
+            }
+
+            UpdateHelpButtons();
+        }
+
+        private void Swap_Click(object sender, RoutedEventArgs e)
+        {
+            if (!GameState.UseHelpCard(HelpCardType.SwapProduct))
+            {
+                Feedback.Text = "Bạn không còn thẻ đổi sản phẩm.";
+                return;
+            }
+
+            Feedback.Text = "🔄 Đã đổi sang sản phẩm khác.";
+            questionIndex--;
+            NextQuestion();
+        }
+
+        private void UpdateHelpButtons()
+        {
+            HintButton.IsEnabled = GameState.GetHelpCount(HelpCardType.Hint) > 0 && !hintUsedThisQuestion;
+            SwapButton.IsEnabled = GameState.GetHelpCount(HelpCardType.SwapProduct) > 0;
+        }
 
         private void Finish_Click(object sender, RoutedEventArgs e) => OpenPunchBoard();
 

--- a/Round2Window.xaml
+++ b/Round2Window.xaml
@@ -21,32 +21,62 @@
 
         <!-- Main content -->
         <Border Grid.Row="1" Background="{StaticResource Card}" CornerRadius="16" Padding="20" Margin="0,12">
-            <StackPanel HorizontalAlignment="Center">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
 
-                <!-- Product Name -->
-                <TextBlock x:Name="ProductName" FontSize="22" FontWeight="SemiBold" TextAlignment="Center"/>
-
-                <!-- Product Image -->
-                <Image x:Name="ProductImage" Height="220" Stretch="Uniform" Margin="0,12"/>
-
-                <!-- Input boxes -->
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,16">
-                    <TextBox x:Name="D1" Width="70" Height="70" FontSize="28" MaxLength="1"
-                   HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="4"/>
-                    <TextBox x:Name="D2" Width="70" Height="70" FontSize="28" MaxLength="1"
-                   HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="4"/>
-                    <TextBox x:Name="D3" Width="70" Height="70" FontSize="28" MaxLength="1"
-                   HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="4"/>
-                    <TextBox x:Name="D4" Width="70" Height="70" FontSize="28" MaxLength="1"
-                   HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="4"/>
+                <StackPanel Grid.Row="0" x:Name="SelectionPanel" Spacing="12">
+                    <TextBlock x:Name="SelectionInstruction" FontSize="22" FontWeight="SemiBold" TextAlignment="Center" TextWrapping="Wrap"/>
+                    <ItemsControl x:Name="SelectionList">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <UniformGrid Columns="2"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border CornerRadius="12" BorderThickness="1" BorderBrush="#3a4a6d" Margin="8" Padding="12">
+                                    <StackPanel>
+                                        <Image Source="{Binding Image}" Height="160" Stretch="Uniform"/>
+                                        <TextBlock Text="{Binding Name}" FontWeight="Bold" Margin="0,8,0,0" TextWrapping="Wrap"/>
+                                        <Button Content="Chọn" Margin="0,8,0,0" Tag="{Binding Index}" Click="SelectionPick_Click"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                 </StackPanel>
 
-                <!-- Check button -->
-                <Button Content="Kiểm tra" Width="140" Height="45" FontSize="18" Click="Check_Click"/>
+                <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,12" Spacing="10">
+                    <Button x:Name="SelectionHintButton" Content="Gợi ý" Click="SelectionHint_Click"/>
+                    <TextBlock x:Name="SelectionFeedback" FontSize="16" TextWrapping="Wrap"/>
+                </StackPanel>
 
-                <!-- Hint -->
-                <TextBlock x:Name="Hint" FontSize="18" Margin="0,14,0,0" TextAlignment="Center"/>
-            </StackPanel>
+                <StackPanel Grid.Row="2" x:Name="DigitsPanel" HorizontalAlignment="Center" Visibility="Collapsed">
+                    <TextBlock x:Name="ProductName" FontSize="22" FontWeight="SemiBold" TextAlignment="Center"/>
+                    <Image x:Name="ProductImage" Height="220" Stretch="Uniform" Margin="0,12"/>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,16">
+                        <TextBox x:Name="D1" Width="70" Height="70" FontSize="28" MaxLength="1"
+                   HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="4"/>
+                        <TextBox x:Name="D2" Width="70" Height="70" FontSize="28" MaxLength="1"
+                   HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="4"/>
+                        <TextBox x:Name="D3" Width="70" Height="70" FontSize="28" MaxLength="1"
+                   HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="4"/>
+                        <TextBox x:Name="D4" Width="70" Height="70" FontSize="28" MaxLength="1"
+                   HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="4"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="10">
+                        <Button Content="Kiểm tra" Width="140" Height="45" FontSize="18" Click="Check_Click"/>
+                        <Button x:Name="DigitHintButton" Content="Gợi ý" Click="DigitHint_Click"/>
+                        <Button x:Name="DigitSwapButton" Content="Đổi sản phẩm" Click="DigitSwap_Click"/>
+                        <Button x:Name="DigitDoubleButton" Content="Nhân đôi thưởng" Click="DigitDouble_Click"/>
+                    </StackPanel>
+                    <TextBlock x:Name="Hint" FontSize="18" Margin="0,14,0,0" TextAlignment="Center"/>
+                </StackPanel>
+            </Grid>
         </Border>
 
     </Grid>

--- a/Round2Window.xaml.cs
+++ b/Round2Window.xaml.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Windows;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
@@ -12,6 +14,10 @@ namespace HayChonGiaDung.Wpf
         private int price4;            // giá tính theo nghìn
         private int timeLeft = 60;     // 60 giây
         private DispatcherTimer timer;
+        private bool selectionNeedsMostExpensive;
+        private Product[] selectionPool = Array.Empty<Product>();
+        private Product selectionAnswer = null!;
+        private bool doubleRewardActive = false;
 
         public Round2Window()
         {
@@ -19,26 +25,7 @@ namespace HayChonGiaDung.Wpf
             this.WindowState = WindowState.Maximized;
             SoundManager.StartRound();
 
-            // Random sản phẩm
-            current = GameState.Catalog.Count > 0
-                ? GameState.Catalog[GameState.Rnd.Next(GameState.Catalog.Count)]
-                : new Product { Name = "Sản phẩm demo", Price = 2_890_000, Image = null };
-
-            ProductName.Text = $"Đoán 4 chữ số cho giá (x.000 ₫): {current.Name}";
-            price4 = Math.Max(1000, current.Price) / 1000;
-
-            ProductImage.Source = null;
-            if (!string.IsNullOrWhiteSpace(current.ImageUrl) &&
-                Uri.IsWellFormedUriString(current.ImageUrl, UriKind.Absolute))
-            {
-                ProductImage.Source = new BitmapImage(new Uri(current.ImageUrl));
-            }
-            else if (!string.IsNullOrWhiteSpace(current.Image))
-            {
-                string path = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets", "Images", current.Image);
-                if (System.IO.File.Exists(path))
-                    ProductImage.Source = new BitmapImage(new Uri(path));
-            }
+            SetupSelectionPhase();
 
             // Khởi tạo timer
             TimerText.Text = timeLeft.ToString();
@@ -75,8 +62,9 @@ namespace HayChonGiaDung.Wpf
             if (guess == target)
             {
                 timer.Stop();
-                Hint.Text = $"✅ Chính xác! Giá: {target:N0}.000 ₫ (+1,000,000 ₫)";
-                GameState.TotalPrize += 1_000_000;
+                int reward = doubleRewardActive ? 2_000_000 : 1_000_000;
+                Hint.Text = $"✅ Chính xác! Giá: {target:N0}.000 ₫ (+{reward:N0} ₫)";
+                GameState.TotalPrize += reward;
                 SoundManager.Correct();
                 this.DialogResult = true;
                 Close();
@@ -105,5 +93,176 @@ namespace HayChonGiaDung.Wpf
             D1.Focus();
             D1.SelectAll();
         }
+
+        private void SetupSelectionPhase()
+        {
+            selectionNeedsMostExpensive = GameState.Rnd.Next(2) == 0;
+            var pool = new List<Product>();
+            if (GameState.Catalog.Count >= 4)
+            {
+                pool = GameState.Catalog.OrderBy(_ => GameState.Rnd.Next()).Take(4).ToList();
+            }
+            else
+            {
+                pool = new List<Product>
+                {
+                    new Product{ Name="Máy xay sinh tố", Price=950_000 },
+                    new Product{ Name="Bình đun siêu tốc", Price=650_000 },
+                    new Product{ Name="Robot hút bụi", Price=6_500_000 },
+                    new Product{ Name="Tủ lạnh mini", Price=3_200_000 }
+                };
+            }
+            selectionPool = pool.ToArray();
+
+            selectionAnswer = selectionNeedsMostExpensive
+                ? selectionPool.OrderByDescending(p => p.Price).First()
+                : selectionPool.OrderBy(p => p.Price).First();
+
+            SelectionInstruction.Text = selectionNeedsMostExpensive
+                ? "Hãy chọn sản phẩm ĐẮT NHẤT để nhận thưởng thêm thời gian"
+                : "Hãy chọn sản phẩm RẺ NHẤT để nhận thưởng thêm thời gian";
+
+            SelectionList.ItemsSource = selectionPool
+                .Select((p, idx) => new SelectionDisplay(idx, p.Name, TryLoadImage(p)))
+                .ToList();
+
+            SelectionPanel.Visibility = Visibility.Visible;
+            SelectionHintButton.IsEnabled = GameState.GetHelpCount(HelpCardType.Hint) > 0;
+            SelectionFeedback.Text = "";
+            DigitsPanel.Visibility = Visibility.Collapsed;
+        }
+
+        private void SelectionPick_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not System.Windows.Controls.Button btn) return;
+            int index = (int)btn.Tag;
+            var chosen = selectionPool[index];
+            bool correct = chosen == selectionAnswer;
+            if (correct)
+            {
+                SelectionFeedback.Text = "✅ Chính xác! +10 giây cho phần đoán giá.";
+                timeLeft += 10;
+                TimerText.Text = timeLeft.ToString();
+                SoundManager.Correct();
+            }
+            else
+            {
+                SelectionFeedback.Text = $"❌ Sai! Đáp án là {selectionAnswer.Name}. Bạn không nhận thêm thời gian.";
+                SoundManager.Wrong();
+            }
+
+            SelectionPanel.Visibility = Visibility.Collapsed;
+            SelectionHintButton.IsEnabled = false;
+
+            InitializeDigitsPhase();
+        }
+
+        private void SelectionHint_Click(object sender, RoutedEventArgs e)
+        {
+            if (!GameState.UseHelpCard(HelpCardType.Hint))
+            {
+                SelectionFeedback.Text = "Bạn không còn thẻ gợi ý.";
+                return;
+            }
+
+            var ordered = selectionNeedsMostExpensive
+                ? selectionPool.OrderByDescending(p => p.Price).Take(2).Select(p => p.Name)
+                : selectionPool.OrderBy(p => p.Price).Take(2).Select(p => p.Name);
+            SelectionFeedback.Text = "🔍 Gợi ý: Đáp án nằm trong " + string.Join(" hoặc ", ordered);
+            SelectionHintButton.IsEnabled = GameState.GetHelpCount(HelpCardType.Hint) > 0;
+        }
+
+        private void InitializeDigitsPhase()
+        {
+            DigitsPanel.Visibility = Visibility.Visible;
+            SelectionFeedback.Text = string.Empty;
+
+            current = GameState.Catalog.Count > 0
+                ? GameState.Catalog[GameState.Rnd.Next(GameState.Catalog.Count)]
+                : new Product { Name = "Sản phẩm demo", Price = 2_890_000, Image = null };
+
+            ProductName.Text = $"Đoán 4 chữ số cho giá (x.000 ₫): {current.Name}";
+            price4 = Math.Max(1000, current.Price) / 1000;
+
+            ProductImage.Source = TryLoadImage(current);
+
+            D1.Text = D2.Text = D3.Text = D4.Text = string.Empty;
+            Hint.Text = string.Empty;
+            doubleRewardActive = false;
+            DigitDoubleButton.IsEnabled = GameState.GetHelpCount(HelpCardType.DoubleReward) > 0;
+            DigitHintButton.IsEnabled = GameState.GetHelpCount(HelpCardType.Hint) > 0;
+            DigitSwapButton.IsEnabled = GameState.GetHelpCount(HelpCardType.SwapProduct) > 0;
+            D1.Focus();
+        }
+
+        private BitmapImage? TryLoadImage(Product product)
+        {
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(product.ImageUrl) &&
+                    Uri.IsWellFormedUriString(product.ImageUrl, UriKind.Absolute))
+                {
+                    return new BitmapImage(new Uri(product.ImageUrl));
+                }
+                else if (!string.IsNullOrWhiteSpace(product.Image))
+                {
+                    string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets", "Images", product.Image);
+                    if (File.Exists(path))
+                        return new BitmapImage(new Uri(path));
+                }
+            }
+            catch { }
+            return null;
+        }
+
+        private void DigitHint_Click(object sender, RoutedEventArgs e)
+        {
+            if (!GameState.UseHelpCard(HelpCardType.Hint))
+            {
+                Hint.Text = "Bạn không còn thẻ gợi ý.";
+                return;
+            }
+
+            string target = price4.ToString("0000");
+            int revealIndex = GameState.Rnd.Next(4);
+            char digit = target[revealIndex];
+            Hint.Text = $"🔍 Gợi ý: Chữ số thứ {revealIndex + 1} là {digit}.";
+            switch (revealIndex)
+            {
+                case 0: D1.Text = digit.ToString(); break;
+                case 1: D2.Text = digit.ToString(); break;
+                case 2: D3.Text = digit.ToString(); break;
+                case 3: D4.Text = digit.ToString(); break;
+            }
+
+            DigitHintButton.IsEnabled = GameState.GetHelpCount(HelpCardType.Hint) > 0;
+        }
+
+        private void DigitSwap_Click(object sender, RoutedEventArgs e)
+        {
+            if (!GameState.UseHelpCard(HelpCardType.SwapProduct))
+            {
+                Hint.Text = "Bạn không còn thẻ đổi sản phẩm.";
+                return;
+            }
+
+            Hint.Text = "🔄 Đã đổi sang sản phẩm khác.";
+            InitializeDigitsPhase();
+        }
+
+        private void DigitDouble_Click(object sender, RoutedEventArgs e)
+        {
+            if (!GameState.UseHelpCard(HelpCardType.DoubleReward))
+            {
+                Hint.Text = "Bạn không còn thẻ nhân đôi.";
+                return;
+            }
+
+            doubleRewardActive = true;
+            Hint.Text = "✨ Nếu trả lời đúng bạn sẽ được nhân đôi thưởng.";
+            DigitDoubleButton.IsEnabled = GameState.GetHelpCount(HelpCardType.DoubleReward) > 0;
+        }
+
+        private record SelectionDisplay(int Index, string Name, BitmapImage? Image);
     }
 }

--- a/Round5Window.xaml
+++ b/Round5Window.xaml
@@ -1,0 +1,63 @@
+<Window x:Class="HayChonGiaDung.Wpf.Round5Window"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Vòng 5 - Tích lũy dồn toa" WindowState="Maximized"
+        Background="{StaticResource Surface}">
+    <Grid Margin="24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <DockPanel Grid.Row="0">
+            <StackPanel Orientation="Vertical" DockPanel.Dock="Left">
+                <TextBlock Text="Vòng 5: Tích lũy dồn toa" FontSize="30" FontWeight="Bold"/>
+                <TextBlock Text="Xếp giá sản phẩm tăng dần. Mỗi vị trí đúng thưởng thêm tiền!" Opacity="0.8"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" Spacing="12" VerticalAlignment="Center">
+                <Border Background="#1d2d4f" CornerRadius="12" Padding="12,6">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <TextBlock Text="💰" FontSize="20"/>
+                        <TextBlock Text="Xu:"/>
+                        <TextBlock x:Name="CoinText" FontWeight="Bold"/>
+                    </StackPanel>
+                </Border>
+                <Border Background="#1d2d4f" CornerRadius="12" Padding="12,6">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <TextBlock Text="Thẻ:"/>
+                        <TextBlock x:Name="CardText" FontWeight="Bold"/>
+                    </StackPanel>
+                </Border>
+                <Border Background="#1d2d4f" CornerRadius="12" Padding="12,6">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <TextBlock Text="Tổng thưởng:"/>
+                        <TextBlock x:Name="PrizeText" FontWeight="Bold"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </DockPanel>
+
+        <Border Grid.Row="1" Background="{StaticResource Card}" CornerRadius="18" Padding="20" Margin="0,16">
+            <DockPanel>
+                <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" HorizontalAlignment="Center" Spacing="12" Margin="0,0,0,12">
+                    <Button x:Name="HintButton" Content="Gợi ý" Click="Hint_Click"/>
+                    <Button x:Name="SwapButton" Content="Đổi sản phẩm" Click="Swap_Click"/>
+                    <Button x:Name="DoubleButton" Content="Nhân đôi phần thưởng" Click="Double_Click"/>
+                    <TextBlock Text="Chọn một sản phẩm để bảo toàn (radio), sau đó gán thứ tự bằng combo." TextWrapping="Wrap" Width="420"/>
+                </StackPanel>
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <WrapPanel x:Name="ProductsPanel" ItemWidth="260" ItemHeight="Auto" HorizontalAlignment="Center"/>
+                </ScrollViewer>
+            </DockPanel>
+        </Border>
+
+        <DockPanel Grid.Row="2" Margin="0,12,0,0">
+            <TextBlock x:Name="Feedback" DockPanel.Dock="Left" FontSize="18" TextWrapping="Wrap" Width="600"/>
+            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" Spacing="12">
+                <Button Content="Hoàn tất" Width="160" Height="50" FontSize="18" Click="Submit_Click"/>
+                <Button Content="Hủy" Width="120" Height="50" FontSize="18" Click="Cancel_Click"/>
+            </StackPanel>
+        </DockPanel>
+    </Grid>
+</Window>

--- a/Round5Window.xaml.cs
+++ b/Round5Window.xaml.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace HayChonGiaDung.Wpf
+{
+    public partial class Round5Window : Window
+    {
+        private readonly List<FinalCard> _cards = new();
+        private bool _doubleActive = false;
+        private const int BaseReward = 700_000;
+        private const int ProtectedConsolation = 300_000;
+
+        public Round5Window()
+        {
+            InitializeComponent();
+            this.WindowState = WindowState.Maximized;
+            SoundManager.StartRound();
+            PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            RefreshHud();
+            BuildCards();
+        }
+
+        private void RefreshHud()
+        {
+            CoinText.Text = GameState.QuickCoins.ToString();
+            CardText.Text = string.Join(", ", GameState.GetInventory().Where(kv => kv.Value > 0)
+                .Select(kv => $"{GetCardName(kv.Key)} x{kv.Value}"));
+            if (string.IsNullOrWhiteSpace(CardText.Text))
+            {
+                CardText.Text = "Chưa có";
+            }
+            HintButton.IsEnabled = GameState.GetHelpCount(HelpCardType.Hint) > 0;
+            SwapButton.IsEnabled = GameState.GetHelpCount(HelpCardType.SwapProduct) > 0;
+            DoubleButton.IsEnabled = !_doubleActive && GameState.GetHelpCount(HelpCardType.DoubleReward) > 0;
+        }
+
+        private static string GetCardName(HelpCardType type) => type switch
+        {
+            HelpCardType.Hint => "Gợi ý",
+            HelpCardType.SwapProduct => "Đổi",
+            HelpCardType.DoubleReward => "Nhân đôi",
+            _ => type.ToString()
+        };
+
+        private void BuildCards()
+        {
+            _cards.Clear();
+            ProductsPanel.Children.Clear();
+
+            var picks = GameState.Catalog.OrderBy(_ => GameState.Rnd.Next()).Take(5).ToList();
+            if (picks.Count < 3)
+            {
+                picks = new List<Product>
+                {
+                    new Product { Name = "Máy lọc nước", Price = 5_200_000 },
+                    new Product { Name = "Bếp từ đôi", Price = 7_800_000 },
+                    new Product { Name = "Lò nướng", Price = 3_400_000 },
+                    new Product { Name = "Máy hút mùi", Price = 4_900_000 }
+                };
+            }
+
+            int count = Math.Min(5, Math.Max(3, picks.Count));
+            picks = picks.Take(count).ToList();
+
+            for (int i = 0; i < picks.Count; i++)
+            {
+                var product = picks[i];
+                var card = CreateCard(product, i, count);
+                _cards.Add(card);
+                ProductsPanel.Children.Add(card.Container);
+            }
+        }
+
+        private FinalCard CreateCard(Product product, int index, int total)
+        {
+            var border = new Border
+            {
+                CornerRadius = new CornerRadius(16),
+                BorderThickness = new Thickness(1),
+                BorderBrush = System.Windows.Media.Brushes.DimGray,
+                Margin = new Thickness(12),
+                Padding = new Thickness(12),
+                Width = 240
+            };
+
+            var stack = new StackPanel();
+            var img = new Image { Height = 160, Stretch = System.Windows.Media.Stretch.UniformToFill, Margin = new Thickness(0, 0, 0, 8) };
+            img.Source = TryLoadImage(product);
+            var name = new TextBlock { Text = product.Name, FontWeight = FontWeights.Bold, FontSize = 18, TextWrapping = TextWrapping.Wrap };
+            var orderBox = new ComboBox { Margin = new Thickness(0, 10, 0, 0), FontSize = 16 };
+            for (int i = 1; i <= total; i++) orderBox.Items.Add(i);
+            orderBox.SelectedIndex = -1;
+            var protect = new RadioButton { Content = "Bảo toàn", GroupName = "ProtectGroup", Margin = new Thickness(0, 10, 0, 0) };
+            var status = new TextBlock { Margin = new Thickness(0, 10, 0, 0), TextWrapping = TextWrapping.Wrap };
+
+            stack.Children.Add(img);
+            stack.Children.Add(name);
+            stack.Children.Add(orderBox);
+            stack.Children.Add(protect);
+            stack.Children.Add(status);
+
+            border.Child = stack;
+
+            return new FinalCard(product, orderBox, protect, status, border);
+        }
+
+        private static BitmapImage? TryLoadImage(Product p)
+        {
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(p.ImageUrl) && Uri.IsWellFormedUriString(p.ImageUrl, UriKind.Absolute))
+                {
+                    return new BitmapImage(new Uri(p.ImageUrl));
+                }
+                if (!string.IsNullOrWhiteSpace(p.Image))
+                {
+                    string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets", "Images", p.Image);
+                    if (File.Exists(path))
+                        return new BitmapImage(new Uri(path));
+                }
+            }
+            catch { }
+            return null;
+        }
+
+        private void Hint_Click(object sender, RoutedEventArgs e)
+        {
+            if (!GameState.UseHelpCard(HelpCardType.Hint))
+            {
+                Feedback.Text = "Bạn không còn thẻ gợi ý.";
+                return;
+            }
+
+            var product = _cards[GameState.Rnd.Next(_cards.Count)].Product;
+            int span = (int)(product.Price * 0.12);
+            Feedback.Text = $"🔍 Gợi ý: {product.Name} có giá khoảng {product.Price - span:N0} ₫ - {product.Price + span:N0} ₫.";
+            RefreshHud();
+        }
+
+        private void Swap_Click(object sender, RoutedEventArgs e)
+        {
+            if (!GameState.UseHelpCard(HelpCardType.SwapProduct))
+            {
+                Feedback.Text = "Bạn không còn thẻ đổi sản phẩm.";
+                return;
+            }
+
+            Feedback.Text = "🔄 Đã đổi danh sách sản phẩm.";
+            BuildCards();
+            RefreshHud();
+        }
+
+        private void Double_Click(object sender, RoutedEventArgs e)
+        {
+            if (!GameState.UseHelpCard(HelpCardType.DoubleReward))
+            {
+                Feedback.Text = "Bạn không còn thẻ nhân đôi.";
+                return;
+            }
+
+            _doubleActive = true;
+            Feedback.Text = "✨ Toàn bộ tiền thưởng vòng này sẽ được nhân đôi nếu xếp đúng.";
+            DoubleButton.IsEnabled = GameState.GetHelpCount(HelpCardType.DoubleReward) > 0;
+            RefreshHud();
+        }
+
+        private void Submit_Click(object sender, RoutedEventArgs e)
+        {
+            var usedOrders = new HashSet<int>();
+            foreach (var card in _cards)
+            {
+                if (card.Order.SelectedItem is not int order)
+                {
+                    Feedback.Text = "Hãy chọn đầy đủ thứ tự cho từng sản phẩm.";
+                    return;
+                }
+                if (!usedOrders.Add(order))
+                {
+                    Feedback.Text = "Mỗi thứ tự chỉ được dùng một lần.";
+                    return;
+                }
+            }
+
+            var sorted = _cards.OrderBy(c => c.Product.Price).ToList();
+            int reward = 0;
+
+            foreach (var card in _cards)
+            {
+                int chosen = (int)card.Order.SelectedItem!;
+                int actualIndex = sorted.IndexOf(sorted.First(c => c.Product == card.Product)) + 1;
+                if (chosen == actualIndex)
+                {
+                    int add = BaseReward;
+                    if (_doubleActive) add *= 2;
+                    reward += add;
+                    card.Status.Text = $"✅ Đúng vị trí! +{add:N0} ₫";
+                }
+                else if (card.Protect.IsChecked == true)
+                {
+                    int add = ProtectedConsolation;
+                    reward += add;
+                    card.Status.Text = $"🛡️ Bảo toàn: +{add:N0} ₫ (vị trí đúng là {actualIndex})";
+                }
+                else
+                {
+                    card.Status.Text = $"❌ Sai. Vị trí đúng: {actualIndex}";
+                }
+            }
+
+            GameState.TotalPrize += reward;
+            PrizeText.Text = $"{GameState.TotalPrize:N0} ₫";
+            Feedback.Text = reward > 0
+                ? $"Bạn nhận thêm {reward:N0} ₫ ở vòng cuối!"
+                : "Bạn chưa nhận thêm tiền thưởng ở vòng này.";
+            SoundManager.Correct();
+            LeaderboardService.AddScore(GameState.PlayerName, GameState.TotalPrize);
+            this.DialogResult = reward > 0;
+            Close();
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            this.DialogResult = false;
+            Close();
+        }
+
+        private record FinalCard(Product Product, ComboBox Order, RadioButton Protect, TextBlock Status, Border Container);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce the QuickStartWindow with trivia questions that award coins and allow players to buy help cards before the main game
- add help card inventory and coin tracking in GameState, surface the data in MainWindow, and thread usage through Round 1 and Round 2 with new alternate guessing mechanics
- create the Round5Window finale where players arrange products by price, with support for hint, swap, and double reward cards and a protect option for risk management

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ce5b516483339e36a0e767d4a3b1