### PR TITLE
Adjust round 5 layout and add result animations

### DIFF
--- a/Round5FinalCard.cs
+++ b/Round5FinalCard.cs
@@ -4,6 +4,14 @@ using System.Windows.Media;
 
 namespace HayChonGiaDung.Wpf
 {
+    public enum Round5EvaluationState
+    {
+        Pending,
+        Win,
+        Protected,
+        Lose
+    }
+
     public class Round5FinalCard : INotifyPropertyChanged
     {
         public Round5FinalCard(Product product, ImageSource? image)
@@ -14,6 +22,20 @@ namespace HayChonGiaDung.Wpf
 
         public Product Product { get; }
         public ImageSource? Image { get; }
+
+        private Round5EvaluationState _evaluationState = Round5EvaluationState.Pending;
+        public Round5EvaluationState EvaluationState
+        {
+            get => _evaluationState;
+            set
+            {
+                if (_evaluationState != value)
+                {
+                    _evaluationState = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
         private bool _isProtected;
         public bool IsProtected

--- a/Round5Window.xaml
+++ b/Round5Window.xaml
@@ -47,44 +47,120 @@
                     <Button x:Name="DoubleButton" Content="Nhân đôi phần thưởng" Click="Double_Click" Margin="12,0,0,0"/>
                     <TextBlock Text="Kéo thả để sắp xếp thứ tự tăng dần. Chọn 1 sản phẩm để bảo toàn." TextWrapping="Wrap" Width="420" Margin="12,0,0,0"/>
                 </StackPanel>
-                <ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <ListBox x:Name="ProductsList"
-                             AlternationCount="10"
-                             AllowDrop="True"
-                             Background="Transparent"
-                             BorderThickness="0"
-                             PreviewMouseLeftButtonDown="ProductsList_PreviewMouseLeftButtonDown"
-                             PreviewMouseMove="ProductsList_PreviewMouseMove"
-                             Drop="ProductsList_Drop">
-                        <ListBox.ItemContainerStyle>
-                            <Style TargetType="ListBoxItem">
-                                <Setter Property="Padding" Value="0"/>
-                                <Setter Property="Margin" Value="0,6"/>
-                                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                                <Setter Property="Background" Value="Transparent"/>
-                            </Style>
-                        </ListBox.ItemContainerStyle>
-                        <ListBox.ItemTemplate>
-                            <DataTemplate DataType="{x:Type local:Round5FinalCard}">
-                                <Border CornerRadius="16" BorderThickness="1" BorderBrush="DimGray" Margin="12" Padding="12">
-                                    <StackPanel>
-                                        <TextBlock Text="{Binding DisplayOrderText}" FontSize="14" FontWeight="SemiBold" Foreground="LightGray"/>
-                                        <Image Source="{Binding Image}" Height="160" Stretch="UniformToFill" Margin="0,4,0,8"/>
-                                        <TextBlock Text="{Binding Product.Name}" FontWeight="Bold" FontSize="18" TextWrapping="Wrap"/>
-                                        <RadioButton Content="Bảo toàn" GroupName="ProtectGroup" Margin="0,10,0,0"
-                                                     IsChecked="{Binding IsProtected, Mode=TwoWay}" Checked="Protect_Checked"/>
-                                        <TextBlock Text="{Binding Status}" Margin="0,10,0,0" TextWrapping="Wrap"/>
-                                    </StackPanel>
-                                </Border>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
-                </ScrollViewer>
+                <ListBox x:Name="ProductsList"
+                         AlternationCount="10"
+                         AllowDrop="True"
+                         Background="Transparent"
+                         BorderThickness="0"
+                         ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                         ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                         PreviewMouseLeftButtonDown="ProductsList_PreviewMouseLeftButtonDown"
+                         PreviewMouseMove="ProductsList_PreviewMouseMove"
+                         Drop="ProductsList_Drop">
+                    <ListBox.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <UniformGrid Columns="3"/>
+                        </ItemsPanelTemplate>
+                    </ListBox.ItemsPanel>
+                    <ListBox.ItemContainerStyle>
+                        <Style TargetType="ListBoxItem">
+                            <Setter Property="Padding" Value="0"/>
+                            <Setter Property="Margin" Value="6"/>
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                            <Setter Property="Background" Value="Transparent"/>
+                        </Style>
+                    </ListBox.ItemContainerStyle>
+                    <ListBox.ItemTemplate>
+                        <DataTemplate DataType="{x:Type local:Round5FinalCard}">
+                            <Border CornerRadius="16" BorderThickness="1" Margin="6" Padding="12">
+                                <Border.Background>
+                                    <SolidColorBrush Color="{Binding Source={StaticResource Card}, Path=Color}"/>
+                                </Border.Background>
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Setter Property="BorderBrush" Value="DimGray"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding EvaluationState}" Value="Win">
+                                                <Setter Property="BorderBrush" Value="#3CB371"/>
+                                                <DataTrigger.EnterActions>
+                                                    <BeginStoryboard>
+                                                        <Storyboard>
+                                                            <ColorAnimation Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)"
+                                                                            To="#1B4227"
+                                                                            Duration="0:0:0.35"
+                                                                            AutoReverse="True"/>
+                                                        </Storyboard>
+                                                    </BeginStoryboard>
+                                                </DataTrigger.EnterActions>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding EvaluationState}" Value="Protected">
+                                                <Setter Property="BorderBrush" Value="#FFB300"/>
+                                                <DataTrigger.EnterActions>
+                                                    <BeginStoryboard>
+                                                        <Storyboard>
+                                                            <ColorAnimation Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)"
+                                                                            To="#3A2D11"
+                                                                            Duration="0:0:0.35"
+                                                                            AutoReverse="True"/>
+                                                        </Storyboard>
+                                                    </BeginStoryboard>
+                                                </DataTrigger.EnterActions>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding EvaluationState}" Value="Lose">
+                                                <Setter Property="BorderBrush" Value="#C62828"/>
+                                                <DataTrigger.EnterActions>
+                                                    <BeginStoryboard>
+                                                        <Storyboard>
+                                                            <ColorAnimation Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)"
+                                                                            To="#3B1717"
+                                                                            Duration="0:0:0.35"
+                                                                            AutoReverse="True"/>
+                                                        </Storyboard>
+                                                    </BeginStoryboard>
+                                                </DataTrigger.EnterActions>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                                <StackPanel>
+                                    <TextBlock Text="{Binding DisplayOrderText}" FontSize="14" FontWeight="SemiBold" Foreground="LightGray"/>
+                                    <Image Source="{Binding Image}" Height="140" Stretch="Uniform" Margin="0,4,0,8"/>
+                                    <TextBlock Text="{Binding Product.Name}" FontWeight="Bold" FontSize="18" TextWrapping="Wrap"/>
+                                    <RadioButton Content="Bảo toàn" GroupName="ProtectGroup" Margin="0,10,0,0"
+                                                 IsChecked="{Binding IsProtected, Mode=TwoWay}" Checked="Protect_Checked"/>
+                                    <TextBlock Text="{Binding Status}" Margin="0,10,0,0" TextWrapping="Wrap">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="LightGray"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding EvaluationState}" Value="Win">
+                                                        <Setter Property="Foreground" Value="#9CCC65"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding EvaluationState}" Value="Protected">
+                                                        <Setter Property="Foreground" Value="#FFCA28"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding EvaluationState}" Value="Lose">
+                                                        <Setter Property="Foreground" Value="#EF5350"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
             </DockPanel>
         </Border>
 
         <DockPanel Grid.Row="2" Margin="0,12,0,0">
-            <TextBlock x:Name="Feedback" DockPanel.Dock="Left" FontSize="18" TextWrapping="Wrap" Width="600"/>
+            <TextBlock x:Name="Feedback" DockPanel.Dock="Left" FontSize="18" TextWrapping="Wrap" Width="600"
+                       Background="Transparent" RenderTransformOrigin="0.5,0.5">
+                <TextBlock.RenderTransform>
+                    <ScaleTransform ScaleX="1" ScaleY="1"/>
+                </TextBlock.RenderTransform>
+            </TextBlock>
             <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
                 <Button Content="Hoàn tất" Width="160" Height="50" FontSize="18" Click="Submit_Click"/>
                 <Button Content="Hủy" Width="120" Height="50" FontSize="18" Click="Cancel_Click" Margin="12,0,0,0"/>


### PR DESCRIPTION
## Summary
- arrange the round 5 product list with a uniform grid so all items stay visible without scrolling
- extend round 5 cards with evaluation state styling and animated highlights for wins, protected picks, and losses
- animate the feedback banner and play win or lose sounds based on the round result

## Testing
- Not run (toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d4dbfd31888333a090003ec4a86a54