### PR TITLE
Improve round 1 clarity and delay countdown start

### DIFF
--- a/Round1Window.xaml
+++ b/Round1Window.xaml
@@ -34,10 +34,13 @@
 
                 <!-- LEFT: product info -->
                 <StackPanel Grid.Column="0" Margin="0,0,18,0">
-                    <TextBlock x:Name="ProductName" FontSize="26" FontWeight="SemiBold" TextWrapping="Wrap" />
-                    <TextBlock Text="Mô tả" FontWeight="Bold" Margin="0,8,0,4"/>
-                    <ScrollViewer Height="120" VerticalScrollBarVisibility="Auto">
-                        <TextBlock x:Name="ProductDesc" TextWrapping="Wrap" Opacity="0.9"/>
+                    <TextBlock x:Name="ProductName" FontSize="28" FontWeight="SemiBold" TextWrapping="Wrap" />
+                    <Border Background="#1D2748" CornerRadius="10" Padding="8" Margin="0,8,0,12">
+                        <TextBlock x:Name="QuantityText" FontSize="20" FontWeight="Bold" Foreground="White"/>
+                    </Border>
+                    <TextBlock Text="Mô tả" FontSize="22" FontWeight="Bold" Margin="0,4,0,6"/>
+                    <ScrollViewer Height="140" VerticalScrollBarVisibility="Auto">
+                        <TextBlock x:Name="ProductDesc" TextWrapping="Wrap" Opacity="0.9" FontSize="18"/>
                     </ScrollViewer>
 
                     <Border CornerRadius="12" Background="#121C3C" Padding="10" Margin="0,12,0,0">

--- a/Round1Window.xaml.cs
+++ b/Round1Window.xaml.cs
@@ -41,7 +41,8 @@ namespace HayChonGiaDung.Wpf
             hiddenPrice = Math.Max(1000, correctPrice + GameState.Rnd.Next(-delta, delta + 1));
 
             // UI text
-            ProductName.Text = $"{current.Name} x{qty}";
+            ProductName.Text = current.Name;
+            QuantityText.Text = $"Số lượng: {qty} chiếc";
             Question.Text = $"{hiddenPrice:N0} ₫ — Giá đúng CAO HƠN hay THẤP HƠN?";
 
             // description (nếu có), fallback câu mặc định

--- a/Round2Window.xaml.cs
+++ b/Round2Window.xaml.cs
@@ -32,7 +32,6 @@ namespace HayChonGiaDung.Wpf
             TimerText.Text = timeLeft.ToString();
             timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
             timer.Tick += Timer_Tick;
-            timer.Start();
         }
 
         private void Timer_Tick(object? sender, EventArgs e)
@@ -178,6 +177,11 @@ namespace HayChonGiaDung.Wpf
         {
             DigitsPanel.Visibility = Visibility.Visible;
             SelectionFeedback.Text = string.Empty;
+
+            if (!timer.IsEnabled)
+            {
+                timer.Start();
+            }
 
             current = GameState.Catalog.Count > 0
                 ? GameState.Catalog[GameState.Rnd.Next(GameState.Catalog.Count)]


### PR DESCRIPTION
## Summary
- enlarge the product description area in round 1 and show quantity in a highlighted chip for better readability
- update round 1 logic to populate the new quantity text
- delay the round 2 countdown timer until the guessing phase begins so selection time is not deducted

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5000f838c8333838cba1b3d1dafad