### PR TITLE
Restrict round 2 products to 4-digit prices

### DIFF
--- a/Round2Window.xaml.cs
+++ b/Round2Window.xaml.cs
@@ -183,9 +183,20 @@ namespace HayChonGiaDung.Wpf
                 timer.Start();
             }
 
-            current = GameState.Catalog.Count > 0
-                ? GameState.Catalog[GameState.Rnd.Next(GameState.Catalog.Count)]
-                : new Product { Name = "Sản phẩm demo", Price = 2_890_000, Image = null };
+            static bool IsValidForRound2(Product product)
+                => product.Price >= 1_000_000 && product.Price <= 9_999_000;
+
+            var eligibleProducts = GameState.Catalog.Where(IsValidForRound2).ToList();
+
+            if (eligibleProducts.Count == 0)
+            {
+                // Nếu không có sản phẩm nào phù hợp (hoặc chưa tải dữ liệu), fallback sang sản phẩm demo
+                current = new Product { Name = "Sản phẩm demo", Price = 2_890_000, Image = null };
+            }
+            else
+            {
+                current = eligibleProducts[GameState.Rnd.Next(eligibleProducts.Count)];
+            }
 
             ProductName.Text = $"Đoán 4 chữ số cho giá (x.000 ₫): {current.Name}";
             price4 = Math.Max(1000, current.Price) / 1000;


### PR DESCRIPTION
## Summary
- only use catalog products priced between 1M and 9.999M VND when starting round 2 so the guessing phase always has exactly four digits
- keep a fallback demo product when no eligible entries are available

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d501cd33d4833399796161aeac07b7