### PR TITLE
Add fireworks celebration sound effect

### DIFF
--- a/FireworksWindow.xaml.cs
+++ b/FireworksWindow.xaml.cs
@@ -30,6 +30,8 @@ namespace HayChonGiaDung.Wpf
 
         private async void Window_Loaded(object sender, RoutedEventArgs e)
         {
+            SoundManager.Fireworks();
+
             if (Owner != null)
             {
                 Left = Owner.Left;

--- a/SoundManager.cs
+++ b/SoundManager.cs
@@ -86,6 +86,7 @@ namespace HayChonGiaDung.Wpf
         public static void StartRound() => PlayOneShot("Choi.wav");
         public static void Win() => PlayOneShot("Win.wav");
         public static void End() => PlayOneShot("End.wav");
+        public static void Fireworks() => PlayOneShot("Am-thanh-chuc-mung-chien-thang-www_tiengdong_com.wav", 0.9);
         public static void PlayPreview(double volume) =>
             PlayOneShot("Correct.wav", Math.Clamp(volume, 0.0, 1.0), bypassMute: true);
 


### PR DESCRIPTION
## Summary
- trigger a celebration sound when the fireworks window loads
- expose a dedicated fireworks helper on the sound manager that plays the celebratory audio clip

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d50c3d8df4833386a18a81d068a771